### PR TITLE
feat(ui): add intrinsic height calculation, SelectionController, and printWidget extension

### DIFF
--- a/examples/01_questionnaire_example.dart
+++ b/examples/01_questionnaire_example.dart
@@ -1,0 +1,133 @@
+// ignore_for_file: file_names
+
+import 'dart:io';
+import 'package:termui/terminal/terminal.dart' as term;
+import 'package:termui/ui/ui.dart';
+
+void main() async {
+  // We run the application inside runGuarded to guarantee that the terminal's
+  // configuration (raw mode, echo, cursor visibility, etc.) is restored safely,
+  // even if an uncaught exception or crash occurs.
+  await term.Terminal.runGuarded((terminal) async {
+    // 1. Immediately disable mouse tracking to clean up any leftover state from previous runs.
+    terminal.disableMouseTracking();
+    // 2. Hide the hardware cursor since we will draw our own cursor style.
+    terminal.hideCursor();
+
+    try {
+      // Reusable styles
+      const questionStyle = Style(
+        modifiers: Modifier.bold,
+        foreground: CharmColors.julep,
+      );
+      const highlightStyle = Style(foreground: Colors.yellow);
+
+      // ==========================================
+      // QUESTION 1: What is your name?
+      // ==========================================
+      // We pass a TextEditingController down to TextField to manage and retrieve
+      // the entered text state without needing GlobalKeys or Builder wrappers.
+      final nameCtrl = TextEditingController(text: '');
+
+      await PromptRunner(
+        terminal: terminal,
+        // Notice: No hardcoded 'height' required! The framework calculates it dynamically
+        // using the widget tree's intrinsic height.
+        widget: Column([
+          const Text('1. What is your name:', style: questionStyle),
+          TextField(
+            controller: nameCtrl,
+            placeholder: 'Enter your name...',
+            style: highlightStyle,
+            focused: true,
+          ),
+        ]),
+      ).run();
+
+      final finalName = nameCtrl.text.trim().isEmpty
+          ? 'Anonymous'
+          : nameCtrl.text.trim();
+      terminal.backend.write('\r\n  ✔ Name saved: $finalName\r\n\r\n');
+
+      // ==========================================
+      // QUESTION 2: Favorite Text Editor
+      // ==========================================
+      // We use the new SelectionController to manage choices and selections.
+      final editors = ['VScode', 'VIM', 'Emacs', 'Zed', 'Notepad'];
+      final editorCtrl = SelectionController<String>(
+        options: editors,
+        initialIndex: 0,
+      );
+
+      await PromptRunner(
+        terminal: terminal,
+        widget: Column([
+          const Text(
+            "2. What's your favorite text editor?",
+            style: questionStyle,
+          ),
+          HorizontalRadioGroup(controller: editorCtrl, focused: true),
+        ]),
+      ).run();
+
+      terminal.backend.write(
+        '\r\n  ✔ Editor choice saved: ${editorCtrl.selected}\r\n\r\n',
+      );
+
+      // ==========================================
+      // QUESTION 3: Preferred Operating System
+      // ==========================================
+      final osOptions = ['Linux', 'macOS', 'Windows'];
+      final osCtrl = SelectionController<String>(
+        options: osOptions,
+        initialIndex: 0,
+      );
+
+      await PromptRunner(
+        terminal: terminal,
+        widget: Column([
+          const Text(
+            "3. What is your preferred operating system?",
+            style: questionStyle,
+          ),
+          HorizontalRadioGroup(controller: osCtrl, focused: true),
+        ]),
+      ).run();
+
+      terminal.backend.write(
+        '\r\n  ✔ OS choice saved: ${osCtrl.selected}\r\n\r\n',
+      );
+
+      // ==========================================
+      // SUMMARY SECTION: Rendered natively via printWidget
+      // ==========================================
+      terminal.backend.write('────────────────────────────────────────\r\n');
+
+      // The new printWidget utility eliminates all Buffer/Renderer boilerplate.
+      terminal.printWidget(
+        Column([
+          const Text(
+            '🎉 QUESTIONNAIRE SUMMARY',
+            style: Style(
+              foreground: CharmColors.julep,
+              modifiers: Modifier.bold,
+            ),
+          ),
+          const SizedBox(height: 1),
+          Text('• Name: $finalName'),
+          Text('• Favorite Editor: ${editorCtrl.selected}'),
+          Text('• Operating System: ${osCtrl.selected}'),
+        ]),
+      );
+
+      terminal.backend.write('\r\n\r\n');
+    } finally {
+      // 3. Guarantee that mouse tracking is disabled and cursor is restored on exit.
+      terminal.disableMouseTracking();
+      terminal.showCursor();
+    }
+  });
+
+  print('Questionnaire completed. Exited cleanly.');
+  exit(0);
+}

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -1,0 +1,14 @@
+name: examples
+description: Examples for termui.
+version: 0.1.0
+publish_to: none
+
+resolution: workspace
+
+environment:
+  sdk: ">=3.11.0 <4.0.0"
+
+dependencies:
+  termui:
+    path: ../packages/termui
+  characters: ^1.4.0

--- a/packages/termui/lib/ui/layout.dart
+++ b/packages/termui/lib/ui/layout.dart
@@ -138,16 +138,55 @@ abstract class BuildContext {
       Zone.current[#buildContext] as BuildContext?;
 }
 
+/// A unique identifier for [Widget] configurations.
+abstract class Key {
+  /// Initializes a key.
+  const Key();
+}
+
+/// A key that is unique across the entire element tree.
+/// Global keys allow widgets to be uniquely identified and retrieved from
+/// the registry.
+class GlobalKey<T extends State<StatefulWidget>> extends Key {
+  static final Map<GlobalKey, Element> _registry = {};
+
+  /// Initializes a global key.
+  const GlobalKey() : super();
+
+  /// Retrieves the current [State] associated with the widget registered with this key.
+  T? get currentState {
+    final element = _registry[this];
+    if (element is StatefulElement) {
+      return element.state as T?;
+    }
+    return null;
+  }
+
+  /// Retrieves the [BuildContext] / [Element] registered with this key.
+  BuildContext? get currentContext => _registry[this];
+
+  /// Retrieves the [Widget] configuration registered with this key.
+  Widget? get currentWidget => _registry[this]?.widget;
+}
+
 /// Abstract base class for all renderable widgets.
 abstract class Widget {
+  /// The optional key for this widget.
+  final Key? key;
+
   /// Initializes the widget configuration.
-  const Widget();
+  const Widget({this.key});
 
   /// Creates an [Element] to manage this widget's location in the tree.
   Element createElement() => LeafElement(this);
 
   /// Renders the widget onto the provided [buffer] within the specified [area].
   void render(Buffer buffer, Rect area);
+
+  /// Computes the intrinsic height of this widget under the given [width] constraint.
+  int getIntrinsicHeight(int width) {
+    return 1;
+  }
 }
 
 /// Instantiated element in the widget tree that keeps track of widget updates and state.
@@ -165,10 +204,18 @@ abstract class Element implements BuildContext {
   /// Adds this element to the tree as a child of [parent].
   void mount(Element? parent) {
     this.parent = parent;
+    final k = widget.key;
+    if (k is GlobalKey) {
+      GlobalKey._registry[k] = this;
+    }
   }
 
   /// Removes this element from the tree.
   void unmount() {
+    final k = widget.key;
+    if (k is GlobalKey && GlobalKey._registry[k] == this) {
+      GlobalKey._registry.remove(k);
+    }
     parent = null;
   }
 
@@ -212,7 +259,7 @@ class LeafElement extends Element {
 /// A widget that has configuration but delegates rendering to its built child.
 abstract class StatelessWidget extends Widget {
   /// Initializes a stateless widget.
-  const StatelessWidget();
+  const StatelessWidget({super.key});
 
   /// Describes the part of the user interface represented by this widget.
   Widget build(BuildContext context);
@@ -225,6 +272,14 @@ abstract class StatelessWidget extends Widget {
     // Statelessly build and render child directly if called outside of an active element tree.
     final rootContext = StatelessElement(this)..mount(null);
     rootContext.render(buffer, area);
+  }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    final rootContext = StatelessElement(this)..mount(null);
+    final h = rootContext.childElement?.widget.getIntrinsicHeight(width) ?? 0;
+    rootContext.unmount();
+    return h;
   }
 }
 
@@ -239,7 +294,7 @@ class StatelessElement extends Element {
   @override
   /// Adds this element to the tree and builds the child element.
   void mount(Element? parent) {
-    this.parent = parent;
+    super.mount(parent);
     rebuild();
   }
 
@@ -288,7 +343,7 @@ class StatelessElement extends Element {
 /// A widget that has mutable state.
 abstract class StatefulWidget extends Widget {
   /// Initializes a stateful widget.
-  const StatefulWidget();
+  const StatefulWidget({super.key});
 
   /// Creates the mutable state for this widget at a given location in the tree.
   State createState();
@@ -301,6 +356,14 @@ abstract class StatefulWidget extends Widget {
     // Lazily run stateful loop if rendered without app container.
     final rootContext = StatefulElement(this)..mount(null);
     rootContext.render(buffer, area);
+  }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    final rootContext = StatefulElement(this)..mount(null);
+    final h = rootContext.childElement?.widget.getIntrinsicHeight(width) ?? 0;
+    rootContext.unmount();
+    return h;
   }
 }
 
@@ -361,7 +424,7 @@ class StatefulElement extends Element {
   @override
   /// Adds this element to the tree, creates the state, and builds the child.
   void mount(Element? parent) {
-    this.parent = parent;
+    super.mount(parent);
     state = (widget as StatefulWidget).createState();
     state._widget = widget as StatefulWidget;
     state._context = this;
@@ -434,6 +497,11 @@ abstract class InheritedWidget extends Widget {
     rootContext.render(buffer, area);
   }
 
+  @override
+  int getIntrinsicHeight(int width) {
+    return child.getIntrinsicHeight(width);
+  }
+
   /// Whether the framework should notify widgets that inherit from this widget.
   bool updateShouldNotify(covariant InheritedWidget oldWidget);
 }
@@ -449,7 +517,7 @@ class InheritedElement extends Element {
   @override
   /// Adds this element to the tree and builds the child element.
   void mount(Element? parent) {
-    this.parent = parent;
+    super.mount(parent);
     rebuild();
   }
 
@@ -835,6 +903,25 @@ class Row extends Widget {
       child.render(viewport, Rect(0, 0, childArea.width, childArea.height));
     }
   }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    if (children.isEmpty) return 0;
+    final constraints = children
+        .map((c) => _getConstraint(c, LayoutDirection.horizontal))
+        .toList();
+    final rects = splitRect(
+      Rect(0, 0, width, 1),
+      constraints,
+      LayoutDirection.horizontal,
+    );
+    var maxH = 0;
+    for (var i = 0; i < children.length; i++) {
+      final h = children[i].getIntrinsicHeight(rects[i].width);
+      if (h > maxH) maxH = h;
+    }
+    return maxH;
+  }
 }
 
 /// An element that manages a [Row] widget.
@@ -922,6 +1009,15 @@ class Column extends Widget {
       final viewport = Viewport(buffer, childArea);
       child.render(viewport, Rect(0, 0, childArea.width, childArea.height));
     }
+  }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    var totalHeight = 0;
+    for (final child in children) {
+      totalHeight += child.getIntrinsicHeight(width);
+    }
+    return totalHeight;
   }
 }
 
@@ -1057,6 +1153,16 @@ class Stack extends Widget {
         child.render(viewport, Rect(0, 0, area.width, area.height));
       }
     }
+  }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    var maxH = 0;
+    for (final child in children) {
+      final h = child.getIntrinsicHeight(width);
+      if (h > maxH) maxH = h;
+    }
+    return maxH;
   }
 }
 
@@ -1197,6 +1303,12 @@ class Positioned extends Widget {
   void render(Buffer buffer, Rect area) {
     child.render(buffer, area);
   }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    if (height != null) return height!;
+    return child.getIntrinsicHeight(width);
+  }
 }
 
 /// An element that manages a [Positioned] widget.
@@ -1258,6 +1370,15 @@ class SizedBox extends Widget {
       final viewport = Viewport(buffer, childArea);
       child!.render(viewport, Rect(0, 0, targetWidth, targetHeight));
     }
+  }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    if (height != null) return height!;
+    if (child != null) {
+      return child!.getIntrinsicHeight(this.width ?? width);
+    }
+    return 0;
   }
 }
 
@@ -1359,6 +1480,13 @@ class ConstrainedBox extends Widget {
     final viewport = Viewport(buffer, childArea);
     child.render(viewport, Rect(0, 0, clampedWidth, clampedHeight));
   }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    final w = width.clamp(constraints.minWidth, constraints.maxWidth);
+    final h = child.getIntrinsicHeight(w);
+    return h.clamp(constraints.minHeight, constraints.maxHeight);
+  }
 }
 
 /// An element that manages a [ConstrainedBox] widget.
@@ -1419,6 +1547,11 @@ class Flexible extends Widget {
   @override
   void render(Buffer buffer, Rect area) {
     child.render(buffer, area);
+  }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    return child.getIntrinsicHeight(width);
   }
 }
 
@@ -1565,6 +1698,14 @@ class Align extends Widget {
 
     final childViewport = Viewport(buffer, childArea);
     child.render(childViewport, Rect(0, 0, childWidth, childHeight));
+  }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    if (heightFactor != null) {
+      return (child.getIntrinsicHeight(width) * heightFactor!).round();
+    }
+    return child.getIntrinsicHeight(width);
   }
 }
 

--- a/packages/termui/lib/ui/ui.dart
+++ b/packages/termui/lib/ui/ui.dart
@@ -1,0 +1,9 @@
+export 'buffer.dart';
+export 'color.dart';
+export 'layout.dart';
+export 'renderer.dart';
+export 'style.dart';
+export 'theme.dart';
+export 'widget_toolkit.dart';
+export 'scroll_controller.dart';
+export 'interactive.dart';

--- a/packages/termui/lib/ui/widget_toolkit.dart
+++ b/packages/termui/lib/ui/widget_toolkit.dart
@@ -36,3 +36,7 @@ export 'animation/animation_effect.dart';
 export 'animation/effects.dart';
 export 'animation/animated_state_mixin.dart';
 export 'widgets/animated_button.dart';
+export 'widgets/stateful_builder.dart';
+export 'widgets/prompt_runner.dart';
+export 'widgets/horizontal_radio_group.dart';
+export 'widgets/selection_controller.dart';

--- a/packages/termui/lib/ui/widgets/horizontal_radio_group.dart
+++ b/packages/termui/lib/ui/widgets/horizontal_radio_group.dart
@@ -1,0 +1,118 @@
+import 'package:characters/characters.dart';
+import '../color.dart';
+import '../event.dart' hide Modifier;
+import '../layout.dart';
+import '../style.dart';
+import 'text.dart';
+import 'selection_controller.dart';
+
+/// A horizontal group of radio-like choices.
+class HorizontalRadioGroup extends StatefulWidget {
+  /// The controller managing the selection state and options.
+  final SelectionController<String> controller;
+
+  /// Whether this group has active keyboard focus.
+  final bool focused;
+
+  /// Creates a [HorizontalRadioGroup].
+  const HorizontalRadioGroup({
+    super.key,
+    required this.controller,
+    this.focused = false,
+  });
+
+  @override
+  State<HorizontalRadioGroup> createState() => HorizontalRadioGroupState();
+}
+
+/// The state class for [HorizontalRadioGroup] managing selections and keyboard routing.
+class HorizontalRadioGroupState extends State<HorizontalRadioGroup> {
+  SelectionController<String>? _listenedController;
+
+  void _onControllerChanged() {
+    setState(() {});
+  }
+
+  void _updateListener() {
+    if (_listenedController != widget.controller) {
+      _listenedController?.removeListener(_onControllerChanged);
+      _listenedController = widget.controller;
+      _listenedController?.addListener(_onControllerChanged);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _updateListener();
+  }
+
+  @override
+  void dispose() {
+    _listenedController?.removeListener(_onControllerChanged);
+    super.dispose();
+  }
+
+  /// Handles option selection and navigation.
+  void handleKeyEvent(KeyEvent event) {
+    final controller = widget.controller;
+    if (event.key == 'left' || event.key == 'h' || event.key == 'backtab') {
+      setState(() {
+        controller.focusedIndex =
+            (controller.focusedIndex - 1) % controller.options.length;
+        if (controller.focusedIndex < 0) {
+          controller.focusedIndex += controller.options.length;
+        }
+      });
+    } else if (event.key == 'right' || event.key == 'l' || event.key == 'tab') {
+      setState(() {
+        controller.focusedIndex =
+            (controller.focusedIndex + 1) % controller.options.length;
+      });
+    } else if (event.key == ' ' ||
+        event.key == 'space' ||
+        event.key == 'enter' ||
+        event.key == '\n' ||
+        event.key == '\r') {
+      setState(() {
+        controller.selectedIndex = controller.focusedIndex;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _updateListener();
+    final optionWidgets = <Widget>[];
+    final controller = widget.controller;
+    for (var i = 0; i < controller.options.length; i++) {
+      if (i > 0) {
+        optionWidgets.add(const SizedBox(width: 4));
+      }
+      final option = controller.options[i];
+      final isSelected = (controller.selectedIndex == i);
+      final isFocused = widget.focused && (controller.focusedIndex == i);
+
+      final box = isSelected ? '[X]' : '[ ]';
+      final text = '$box $option';
+
+      final style = isFocused
+          ? const Style(modifiers: Modifier.reverse, foreground: Colors.yellow)
+          : (isSelected
+                ? const Style(
+                    foreground: Colors.yellow,
+                    modifiers: Modifier.bold,
+                  )
+                : const Style(foreground: Colors.white));
+
+      optionWidgets.add(
+        SizedBox(
+          width: text.characters.length,
+          child: Text(text, style: style),
+        ),
+      );
+    }
+
+    return Row(optionWidgets);
+  }
+}

--- a/packages/termui/lib/ui/widgets/padding.dart
+++ b/packages/termui/lib/ui/widgets/padding.dart
@@ -32,6 +32,13 @@ class Padding extends Widget {
     final childViewport = Viewport(buffer, childArea);
     child.render(childViewport, Rect(0, 0, childWidth, childHeight));
   }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    final childWidth = width - padding.left - padding.right;
+    if (childWidth <= 0) return padding.top + padding.bottom;
+    return child.getIntrinsicHeight(childWidth) + padding.top + padding.bottom;
+  }
 }
 
 /// An element that represents a [Padding] widget.

--- a/packages/termui/lib/ui/widgets/prompt_runner.dart
+++ b/packages/termui/lib/ui/widgets/prompt_runner.dart
@@ -1,0 +1,197 @@
+import 'dart:io';
+import '../../terminal/terminal.dart' as term;
+import '../buffer.dart';
+import '../layout.dart';
+import '../renderer.dart';
+
+/// A helper class to run an interactive terminal prompt inline.
+/// It encapsulates the event loop, rendering to an inline buffer, and lifecycle management.
+class PromptRunner<T> {
+  /// The active terminal instance.
+  final term.Terminal terminal;
+
+  /// The root widget configuration to display.
+  final Widget widget;
+
+  /// The height constraint of the inline rendering block. If null, calculated dynamically.
+  final int? height;
+
+  /// Whether pressing Enter automatically completes/confirms the prompt.
+  final bool completeOnEnter;
+
+  /// An optional key event handler callback. Returns true if prompt is completed.
+  final bool Function(term.KeyEvent event)? onKeyEvent;
+
+  /// An optional completion callback returning the final value of type [T].
+  final T Function()? onComplete;
+
+  /// Creates a new [PromptRunner].
+  PromptRunner({
+    required this.terminal,
+    required this.widget,
+    this.height,
+    this.completeOnEnter = true,
+    this.onKeyEvent,
+    this.onComplete,
+  });
+
+  /// Starts the inline prompt loop and returns a Future containing the final result.
+  Future<T?> run() async {
+    final termSize = await terminal.size;
+    final width = termSize.x;
+
+    // Autosize the height dynamically if not explicitly specified.
+    final computedHeight = height ?? widget.getIntrinsicHeight(width);
+
+    // Create a temporary buffer and inline renderer.
+    final buffer = Buffer.blank(width, computedHeight);
+    final renderer = Renderer(
+      width,
+      computedHeight,
+      mode: RenderingMode.inline,
+    );
+
+    // Mount the widget tree element persistently so states and focus configuration
+    // are retained between keyboard event loop iterations.
+    final rootElement = widget.createElement()..mount(null);
+
+    void draw() {
+      // Rebuild the element tree to consume any new state modifications.
+      final el = rootElement;
+      if (el is StatefulElement) {
+        el.rebuild();
+      } else if (el is StatelessElement) {
+        el.rebuild();
+      } else {
+        try {
+          (el as dynamic).rebuild();
+        } catch (_) {}
+      }
+
+      buffer.clear();
+      // Render the rebuilt element tree on our double buffer canvas.
+      rootElement.render(buffer, Rect(0, 0, width, computedHeight));
+
+      final sb = StringBuffer();
+      renderer.render(buffer, sb);
+      if (sb.isNotEmpty) {
+        terminal.backend.write(sb.toString());
+      }
+    }
+
+    // Connect the static repainter callback so that inner setState() invocations
+    // (e.g. from typing inside a TextField) trigger screen updates.
+    State.onNeedRepaint = draw;
+
+    // Initial frame draw
+    draw();
+
+    try {
+      await for (final event in terminal.events) {
+        if (event is term.KeyEvent) {
+          // Cleanly catch Ctrl+C to restore cursor and exit
+          if (event.key.length == 1 && event.key.codeUnits[0] == 3) {
+            terminal.showCursor();
+            exit(0);
+          }
+
+          var isDone = false;
+
+          // 1. Let custom interceptor handle the key event first
+          if (onKeyEvent != null) {
+            isDone = onKeyEvent!(event);
+          }
+
+          // 2. If not custom-intercepted, route the event down to the focused widgets
+          if (!isDone) {
+            _routeKeyEvent(rootElement, event);
+          }
+
+          // 3. Check if we should auto-complete on Enter
+          if (completeOnEnter &&
+              (event.key == 'enter' ||
+                  event.key == '\n' ||
+                  event.key == '\r')) {
+            isDone = true;
+          }
+
+          // Force a redraw to reflect any selections or edits.
+          draw();
+
+          if (isDone) {
+            break;
+          }
+        }
+      }
+    } finally {
+      // Reset the repaint handler to avoid leaks.
+      State.onNeedRepaint = null;
+    }
+
+    if (onComplete != null) {
+      return onComplete!();
+    }
+    return null;
+  }
+
+  /// Recursively walks the element tree to find the focused element and route the key event.
+  void _routeKeyEvent(Element element, term.KeyEvent event) {
+    final widget = element.widget;
+    bool isFocused = false;
+    try {
+      isFocused = (widget as dynamic).focused == true;
+    } catch (_) {}
+
+    if (element is StatefulElement) {
+      try {
+        isFocused =
+            isFocused || (element.state as dynamic).widget.focused == true;
+      } catch (_) {}
+    }
+
+    if (isFocused) {
+      var handledByState = false;
+      if (element is StatefulElement) {
+        try {
+          (element.state as dynamic).handleKeyEvent(event);
+          handledByState = true;
+        } catch (_) {}
+      }
+      if (!handledByState) {
+        try {
+          (widget as dynamic).handleKeyEvent(event);
+        } catch (_) {}
+      }
+    }
+
+    element.visitChildren((child) {
+      _routeKeyEvent(child, event);
+    });
+  }
+}
+
+/// Extension on [term.Terminal] to print a widget inline using the double-buffered renderer layout.
+extension PrintWidgetExtension on term.Terminal {
+  /// Renders and prints the given [widget] to standard output at the current inline cursor position.
+  void printWidget(Widget widget) {
+    var width = backend.size.x;
+    if (width <= 0) {
+      width = 80;
+    }
+
+    final height = widget.getIntrinsicHeight(width);
+
+    final buffer = Buffer.blank(width, height);
+    final element = widget.createElement();
+    element.mount(null);
+    element.render(buffer, Rect(0, 0, width, height));
+    element.unmount();
+
+    final renderer = Renderer(width, height, mode: RenderingMode.inline);
+    final sb = StringBuffer();
+    renderer.render(buffer, sb);
+    if (sb.isNotEmpty) {
+      backend.write(sb.toString());
+    }
+  }
+}

--- a/packages/termui/lib/ui/widgets/selection_controller.dart
+++ b/packages/termui/lib/ui/widgets/selection_controller.dart
@@ -1,0 +1,53 @@
+/// A controller that manages selection state for selection-based widgets.
+class SelectionController<T> {
+  /// The options available for selection.
+  final List<T> options;
+
+  int _selectedIndex;
+  int _focusedIndex;
+  final List<void Function()> _listeners = [];
+
+  /// Creates a new [SelectionController].
+  SelectionController({required this.options, int initialIndex = 0})
+    : _selectedIndex = initialIndex,
+      _focusedIndex = initialIndex;
+
+  /// The index of the currently selected option.
+  int get selectedIndex => _selectedIndex;
+  set selectedIndex(int index) {
+    if (_selectedIndex != index) {
+      _selectedIndex = index;
+      _notify();
+    }
+  }
+
+  /// The index of the option that has keyboard focus.
+  int get focusedIndex => _focusedIndex;
+  set focusedIndex(int index) {
+    if (_focusedIndex != index) {
+      _focusedIndex = index;
+      _notify();
+    }
+  }
+
+  /// The currently selected option value.
+  T get selected => options[_selectedIndex];
+  set selected(T value) {
+    final index = options.indexOf(value);
+    if (index != -1) {
+      selectedIndex = index;
+    }
+  }
+
+  /// Adds a listener to be notified of selection changes.
+  void addListener(void Function() listener) => _listeners.add(listener);
+
+  /// Removes a previously registered listener.
+  void removeListener(void Function() listener) => _listeners.remove(listener);
+
+  void _notify() {
+    for (final listener in List<void Function()>.from(_listeners)) {
+      listener();
+    }
+  }
+}

--- a/packages/termui/lib/ui/widgets/stateful_builder.dart
+++ b/packages/termui/lib/ui/widgets/stateful_builder.dart
@@ -1,0 +1,26 @@
+import '../layout.dart';
+
+/// A custom stateful builder widget matching standard Flutter patterns.
+/// It allows stateful builders to declare their widget layouts dynamically
+/// and obtain local access to `setState` to trigger rebuilds within inline loops.
+class StatefulBuilder extends StatefulWidget {
+  /// The builder callback.
+  final Widget Function(
+    BuildContext context,
+    void Function(void Function()) setState,
+  )
+  builder;
+
+  /// Creates a [StatefulBuilder].
+  const StatefulBuilder({required this.builder});
+
+  @override
+  State<StatefulBuilder> createState() => _StatefulBuilderState();
+}
+
+class _StatefulBuilderState extends State<StatefulBuilder> {
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(context, setState);
+  }
+}

--- a/packages/termui/lib/ui/widgets/text.dart
+++ b/packages/termui/lib/ui/widgets/text.dart
@@ -95,6 +95,16 @@ class Text extends Widget {
     }
   }
 
+  @override
+  int getIntrinsicHeight(int width) {
+    if (!wrap) {
+      return maxLines != null ? min(maxLines!, 1) : 1;
+    }
+    final lines = _wrapText(data, width);
+    final count = lines.length;
+    return maxLines != null ? min(maxLines!, count) : count;
+  }
+
   void _renderLines(Buffer buffer, Rect area, List<String> lines) {
     final limit = maxLines != null ? min(maxLines!, area.height) : area.height;
     for (var i = 0; i < lines.length; i++) {

--- a/packages/termui/lib/ui/widgets/text_field.dart
+++ b/packages/termui/lib/ui/widgets/text_field.dart
@@ -338,6 +338,7 @@ class TextField extends StatefulWidget {
 
   /// Creates a [TextField].
   TextField({
+    super.key,
     String initialText = '',
     String? value,
     int? cursorPosition,
@@ -814,6 +815,13 @@ class TextField extends StatefulWidget {
 
   @override
   State createState() => TextFieldState();
+
+  @override
+  int getIntrinsicHeight(int width) {
+    if (!multiline) return 1;
+    final lines = value.split('\n');
+    return max(1, lines.length);
+  }
 }
 
 /// The state for a [TextField].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ workspace:
   - packages/termui_flutter/example
   - packages/termui_shared_examples
   - packages/termui_recorder
+  - examples
 
 dev_dependencies:
   melos: ^7.0.0


### PR DESCRIPTION
This starts a quest to have more workable / meaningful examples for the library. In doing so, I get to see the rough spots and polish them a little bit.

- Add a root-level questionnaire example to demonstrate the new controller-based and auto-sizing APIs.
- Implement `getIntrinsicHeight` across all layout containers and core widgets to support unconstrained dry-runs.
- Introduce `SelectionController` to manage state for horizontal radio groups and lists.
- Fix `GlobalKey` registration by ensuring all element subclasses invoke `super.mount(parent)`.
- Add `Terminal.printWidget` extension to render and output widget trees inline with zero boilerplate.
- Bundle exports under a new `package:termui/ui/ui.dart` entrypoint.
