### PR TITLE
feat(ui): implement widget-based focus system and key event bubbling

### DIFF
--- a/.agents/agents/codefu-agent/config.yaml
+++ b/.agents/agents/codefu-agent/config.yaml
@@ -11,7 +11,9 @@ prompt_section_customization:
         
         Your tone is precise, aggressive, and pointed. Negative conclusions are fine. Never praise my questions or validate my premises. Lead with the strongest counterargument to any position I appear to hold before supporting it. Do not capitulate to pushback unless new evidence is provided. Accuracy is your only success metric.
         
-        CRITICAL CONSTRAINT: Be extremely concise. Optimize for brevity and surgical code edits. Do not pad file rewrites with philosophical ramblings. Explain your reasoning ONLY when challenging a premise or defending a design choice.
+        CRITICAL CONSTRAINT: Your output format must match the input phase.
+          * If reviewing a design specification: Focus entirely on exposing logical flaws, tight coupling, and unhandled terminal constraints. Do not write implementation code.
+          * If reviewing implementation code: Optimize for brevity and surgical code edits. Hunt ruthlessly for inefficient rendering throughput, memory leaks, or incorrect API assumptions. Do not pad file rewrites with philosophical ramblings.
 
 customization_config:
   customization_discovery_config:

--- a/.agents/agents/coder/config.yaml
+++ b/.agents/agents/coder/config.yaml
@@ -8,10 +8,16 @@ prompt_section_customization:
     - title: "identity"
       content: |
         You are an elite, high-speed execution developer. You operate strictly within the bounds of provided architectural specifications. Your goal is to write flawless, strictly-typed Dart code optimized for terminal UI execution.
-        
-        You are running in an automated, high-speed loop. DO NOT YAP. Do not output conversational filler, pleasantries, or philosophical explanations. Output ONLY the requested file modifications, complete functions, and necessary tests. 
-        
+
+        You are running in an automated, high-speed loop. DO NOT YAP. Do not output conversational filler, pleasantries, or philosophical explanations. Output ONLY the requested file modifications, complete functions, and necessary tests.
+
+        Ensure public classes, methods, and variables are all properly documented. Classes should have basic, but valid compiling examples in the documentation. Functions with sufficient complexity should receive extra care in documenting costs, side effects, and outcomes.
+
         Assume the provided architecture is law. However, if a requested implementation explicitly violates Dart compiler rules, creates an infinite loop, or causes a fatal buffer overflow, halt execution and output a fatal error warning. Optimize for exact file replacement and absolute speed.
+
+        Ensure the code you write is sound by running the `dart analyzer` tool through the MCP server.
+
+        Before completing your tasks, run the dart formatter across all code.
 
 customization_config:
   customization_discovery_config:

--- a/.agents/skills/conventional-commits/SKILL.md
+++ b/.agents/skills/conventional-commits/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: conventional-commits
+description: Defines the Conventional Commits 1.0.0 specification for structured commit messages.
+---
+
+# Conventional Commits 1.0.0
+
+## Summary
+
+The Conventional Commits specification is a lightweight convention on top of
+commit messages. It provides an easy set of rules for creating an explicit
+commit history; which makes it easier to write automated tools on top of.
+This convention dovetails with [SemVer](http://semver.org), by describing the
+features, fixes, and breaking changes made in commit messages.
+
+The commit message should be structured as follows:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+The commit contains the following structural elements, to communicate intent to
+the consumers of your library:
+
+1. **fix:** a commit of the _type_ `fix` patches a bug in your codebase (this
+   correlates with [`PATCH`](http://semver.org/#summary) in Semantic
+   Versioning).
+2. **feat:** a commit of the _type_ `feat` introduces a new feature to the
+   codebase (this correlates with [`MINOR`](http://semver.org/#summary) in
+   Semantic Versioning).
+3. **BREAKING CHANGE:** a commit that has a footer `BREAKING CHANGE:`, or
+   appends a `!` after the type/scope, introduces a breaking API change
+   (correlating with [`MAJOR`](http://semver.org/#summary) in Semantic
+   Versioning). A BREAKING CHANGE can be part of commits of any _type_.
+4. _types_ other than `fix:` and `feat:` are allowed, for example
+   [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
+   (based on the [Angular
+   convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines))
+   recommends `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`,
+   `test:`, and others.
+5. _footers_ other than `BREAKING CHANGE: <description>` may be provided and
+   follow a convention similar to [git trailer
+   format](https://git-scm.com/docs/git-interpret-trailers).
+
+Additional types are not mandated by the Conventional Commits specification, and
+have no implicit effect in Semantic Versioning (unless they include a BREAKING
+CHANGE).
+
+A scope may be provided to a commit's type, to provide additional contextual
+information and is contained within parenthesis, e.g., `feat(parser): add
+ability to parse arrays`.
+
+## Examples
+
+### Commit message with description and breaking change footer
+```
+feat: allow provided config object to extend other configs
+
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+### Commit message with `!` to draw attention to breaking change
+```
+feat!: send an email to the customer when a product is shipped
+```
+
+### Commit message with scope and `!` to draw attention to breaking change
+```
+feat(api)!: send an email to the customer when a product is shipped
+```
+
+### Commit message with both `!` and BREAKING CHANGE footer
+```
+feat!: drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```
+
+### Commit message with no body
+```
+docs: correct spelling of CHANGELOG
+```
+
+### Commit message with scope
+```
+feat(lang): add Polish language
+```
+
+### Commit message with multi-paragraph body and multiple footers
+```
+fix: prevent racing of requests
+
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
+
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
+
+Reviewed-by: Z
+Refs: #123
+```
+
+## Specification
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+1. Commits MUST be prefixed with a type, which consists of a noun, `feat`,
+   `fix`, etc., followed by the OPTIONAL scope, OPTIONAL `!`, and REQUIRED
+   terminal colon and space.
+2. The type `feat` MUST be used when a commit adds a new feature to your
+   application or library.
+3. The type `fix` MUST be used when a commit represents a bug fix for your
+   application.
+4. A scope MAY be provided after a type. A scope MUST consist of a noun
+   describing a section of the codebase surrounded by parenthesis, e.g.,
+   `fix(parser):`
+5. A description MUST immediately follow the colon and space after the
+   type/scope prefix. The description is a short summary of the code changes,
+   e.g., _fix: array parsing issue when multiple spaces were contained in
+   string_.
+6. A longer commit body MAY be provided after the short description, providing
+   additional contextual information about the code changes. The body MUST
+   begin one blank line after the description.
+7. A commit body is free-form and MAY consist of any number of newline
+   separated paragraphs.
+8. One or more footers MAY be provided one blank line after the body. Each
+   footer MUST consist of a word token, followed by either a `:<space>` or
+   `<space>#` separator, followed by a string value (this is inspired by the
+   [git trailer convention](https://git-scm.com/docs/git-interpret-trailers)).
+9. A footer's token MUST use `-` in place of whitespace characters, e.g.,
+   `Acked-by` (this helps differentiate the footer section from a
+   multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY
+   also be used as a token.
+10. A footer's value MAY contain spaces and newlines, and parsing MUST
+    terminate when the next valid footer token/separator pair is observed.
+11. Breaking changes MUST be indicated in the type/scope prefix of a commit, or
+    as an entry in the footer.
+12. If included as a footer, a breaking change MUST consist of the uppercase
+    text BREAKING CHANGE, followed by a colon, space, and description, e.g.,
+    _BREAKING CHANGE: environment variables now take precedence over config
+    files_.
+13. If included in the type/scope prefix, breaking changes MUST be indicated by
+    a `!` immediately before the `:`. If `!` is used, `BREAKING CHANGE:` MAY
+    be omitted from the footer section, and the commit description SHALL be
+    used to describe the breaking change.
+14. Types other than `feat` and `fix` MAY be used in your commit messages,
+    e.g., _docs: update ref docs._
+15. The units of information that make up Conventional Commits MUST NOT be
+    treated as case-sensitive by implementors, with the exception of BREAKING
+    CHANGE which MUST be uppercase.
+16. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a
+    token in a footer.
+
+## Why Use Conventional Commits
+
+* Automatically generating CHANGELOGs.
+* Automatically determining a semantic version bump (based on the types of
+  commits landed).
+* Communicating the nature of changes to teammates, the public, and other
+  stakeholders.
+* Triggering build and publish processes.
+* Making it easier for people to contribute to your projects, by allowing them
+  to explore a more structured commit history.
+
+## FAQ
+
+### How should I deal with commit messages in the initial development phase?
+
+We recommend that you proceed as if you've already released the product.
+Typically *somebody*, even if it's your fellow software developers, is using
+your software. They'll want to know what's fixed, what breaks etc.
+
+### Are the types in the commit title uppercase or lowercase?
+
+Any casing may be used, but it's best to be consistent.
+
+### What do I do if the commit conforms to more than one of the commit types?
+
+Go back and make multiple commits whenever possible. Part of the benefit of
+Conventional Commits is its ability to drive us to make more organized commits
+and PRs.
+
+### Doesn’t this discourage rapid development and fast iteration?
+
+It discourages moving fast in a disorganized way. It helps you be able to move
+fast long term across multiple projects with varied contributors.
+
+### Might Conventional Commits lead developers to limit the type of commits they make because they'll be thinking in the types provided?
+
+Conventional Commits encourages us to make more of certain types of commits
+such as fixes. Other than that, the flexibility of Conventional Commits allows
+your team to come up with their own types and change those types over time.
+
+### How does this relate to SemVer?
+
+`fix` type commits should be translated to `PATCH` releases. `feat` type commits
+should be translated to `MINOR` releases. Commits with `BREAKING CHANGE` in the
+commits, regardless of type, should be translated to `MAJOR` releases.
+
+### How should I version my extensions to the Conventional Commits Specification, e.g. `@jameswomack/conventional-commit-spec`?
+
+We recommend using SemVer to release your own extensions to this specification
+(and encourage you to make these extensions!)
+
+### What do I do if I accidentally use the wrong commit type?
+
+#### When you used a type that's of the spec but not the correct type, e.g. `fix` instead of `feat`
+
+Prior to merging or releasing the mistake, we recommend using `git rebase -i`
+to edit the commit history. After release, the cleanup will be different
+according to what tools and processes you use.
+
+#### When you used a type *not* of the spec, e.g. `feet` instead of `feat`
+
+In a worst case scenario, it's not the end of the world if a commit lands that
+does not meet the Conventional Commits specification. It simply means that
+commit will be missed by tools that are based on the spec.
+
+### Do all my contributors need to use the Conventional Commits specification?
+
+No! If you use a squash based workflow on Git lead maintainers can clean up the
+commit messages as they're merged—adding no workload to casual committers. A
+common workflow for this is to have your git system automatically squash
+commits from a pull request and present a form for the lead maintainer to
+enter the proper git commit message for the merge.
+
+### How does Conventional Commits handle revert commits?
+
+Reverting code can be complicated: are you reverting multiple commits? if you
+revert a feature, should the next release instead be a patch?
+
+Conventional Commits does not make an explicit effort to define revert behavior.
+Instead we leave it to tooling authors to use the flexibility of _types_ and
+_footers_ to develop their logic for handling reverts.
+
+One recommendation is to use the `revert` type, and a footer that references the
+commit SHAs that are being reverted:
+
+```
+revert: let us never again speak of the noodle incident
+
+Refs: 676104e, a215868
+```

--- a/packages/termui/lib/ui/layout.dart
+++ b/packages/termui/lib/ui/layout.dart
@@ -398,6 +398,9 @@ abstract class State<T extends StatefulWidget> {
   /// Called when a dependency of this [State] object changes.
   void didChangeDependencies() {}
 
+  /// Called whenever the widget configuration changes.
+  void didUpdateWidget(covariant T oldWidget) {}
+
   /// Called when this object is removed from the tree permanently.
   void dispose() {}
 
@@ -466,8 +469,10 @@ class StatefulElement extends Element {
   @override
   /// Updates the element with a new [Widget] and triggers a state update.
   void update(Widget newWidget) {
+    final oldWidget = state.widget;
     super.update(newWidget);
     state._widget = newWidget as StatefulWidget;
+    state.didUpdateWidget(oldWidget);
     state.didChangeDependencies();
     rebuild();
   }

--- a/packages/termui/lib/ui/widgets/focus.dart
+++ b/packages/termui/lib/ui/widgets/focus.dart
@@ -1,92 +1,164 @@
 import 'dart:async';
 import '../layout.dart';
 import '../window.dart';
+import '../event.dart';
 
 /// A widget that manages a [FocusNode] to allow keyboard focus tracking and traversal in the widget tree.
-///
-/// Automatically mounts the supplied [focusNode] to the closest ancestor focus scope
-/// on [State.didChangeDependencies] and unmounts it on [State.dispose] to ensure the keyboard focus tree
-/// stays synchronized with the layout.
-///
-/// ### Example
-/// ```dart
-/// final node = FocusNode();
-/// Focus(
-///   focusNode: node,
-///   autofocus: true,
-///   child: MyInputWidget(),
-/// )
-/// ```
 class Focus extends StatefulWidget {
   /// The child subtree that this focus widget hosts.
   final Widget child;
 
   /// The focus node that represents the focus handle.
-  final FocusNode focusNode;
+  final FocusNode? focusNode;
 
   /// Whether this focus node should automatically request focus when mounted.
   final bool autofocus;
 
+  /// Callback executed when a key event hits this node.
+  final bool Function(KeyEvent event)? onKeyEvent;
+
+  /// Callback executed when this focus node gains or loses focus.
+  final void Function(bool hasFocus)? onFocusChange;
+
   /// Creates a new [Focus] widget.
   const Focus({
+    super.key,
     required this.child,
-    required this.focusNode,
+    this.focusNode,
     this.autofocus = false,
+    this.onKeyEvent,
+    this.onFocusChange,
   });
 
   @override
-  State createState() => FocusState();
+  State<Focus> createState() => FocusState();
 
   /// Finds the nearest ancestor [FocusNode] in the widget tree.
   static FocusNode? of(BuildContext context) {
-    final scope = context
-        .dependOnInheritedWidgetOfExactType<_FocusScopeWidget>();
+    final scope = context.dependOnInheritedWidgetOfExactType<FocusMarker>();
     return scope?.focusNode;
   }
 }
 
 /// The state for a [Focus] widget.
 class FocusState extends State<Focus> {
-  FocusNode? _parentRegistration;
+  late FocusNode _focusNode;
+
+  /// The underlying [FocusNode] managed by this state.
+  FocusNode get focusNode => _focusNode;
+
+  /// Factory method to construct the appropriate [FocusNode] instance.
+  FocusNode createFocusNode() {
+    return FocusNode(id: 'focus_${widget.hashCode}');
+  }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    final parentNode = Focus.of(context);
-    if (_parentRegistration != parentNode) {
-      _parentRegistration?.children.remove(widget.focusNode);
-      widget.focusNode.parent = parentNode;
-      parentNode?.addChild(widget.focusNode);
-      _parentRegistration = parentNode;
+  void initState() {
+    super.initState();
+    _focusNode = widget.focusNode ?? createFocusNode();
+    _updateNodeProperties();
+    if (widget.autofocus) {
+      // Trigger requestFocus during the next microtask queue
+      scheduleMicrotask(() {
+        if (mounted) _focusNode.requestFocus();
+      });
     }
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final parentScope = FocusScope.of(context);
+    if (_focusNode.parent != parentScope) {
+      _focusNode.parent?.children.remove(_focusNode);
+      _focusNode.parent = null;
+      if (parentScope != null) {
+        parentScope.addChild(_focusNode);
+      }
+    }
+  }
+
+  @override
+  void didUpdateWidget(Focus oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.focusNode != oldWidget.focusNode) {
+      final hadPrimaryFocus = FocusManager.instance.primaryFocus == _focusNode;
+      _focusNode.dispose();
+      _focusNode = widget.focusNode ?? createFocusNode();
+      _updateNodeProperties();
+      final parentScope = FocusScope.of(context);
+      if (parentScope != null) {
+        parentScope.addChild(_focusNode);
+      }
+      if (hadPrimaryFocus) {
+        _focusNode.requestFocus();
+      }
+    } else {
+      _updateNodeProperties();
+    }
+  }
+
+  void _updateNodeProperties() {
+    _focusNode.onKeyEvent = widget.onKeyEvent;
+    _focusNode.onFocusChange = widget.onFocusChange;
+  }
+
+  @override
   void dispose() {
-    _parentRegistration?.children.remove(widget.focusNode);
-    widget.focusNode.parent = null;
+    _focusNode.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    if (widget.autofocus && !widget.focusNode.isFocused) {
-      scheduleMicrotask(() {
-        if (mounted) {
-          widget.focusNode.requestFocus();
-        }
-      });
-    }
-    return _FocusScopeWidget(focusNode: widget.focusNode, child: widget.child);
+    return FocusMarker(focusNode: _focusNode, child: widget.child);
   }
 }
 
-class _FocusScopeWidget extends InheritedWidget {
-  final FocusNode focusNode;
-
-  const _FocusScopeWidget({required this.focusNode, required super.child});
+/// A specialized widget to manage focus navigation traversal.
+class FocusScope extends Focus {
+  /// Creates a new [FocusScope] widget.
+  const FocusScope({
+    super.key,
+    required super.child,
+    FocusScopeNode? super.focusNode,
+    super.autofocus,
+    super.onKeyEvent,
+    super.onFocusChange,
+  });
 
   @override
-  bool updateShouldNotify(_FocusScopeWidget oldWidget) =>
+  State<Focus> createState() => FocusScopeState();
+
+  /// Walks up Context to obtain the closest FocusScopeNode.
+  static FocusScopeNode? of(BuildContext context) {
+    final marker = context.dependOnInheritedWidgetOfExactType<FocusMarker>();
+    var node = marker?.focusNode;
+    while (node != null) {
+      if (node is FocusScopeNode) return node;
+      node = node.parent;
+    }
+    return null;
+  }
+}
+
+/// The state for a [FocusScope] widget.
+class FocusScopeState extends FocusState {
+  @override
+  FocusNode createFocusNode() {
+    return FocusScopeNode(id: 'scope_${widget.hashCode}');
+  }
+}
+
+/// An InheritedWidget to propagate [FocusNode] down the BuildContext hierarchy.
+class FocusMarker extends InheritedWidget {
+  /// The [FocusNode] to propagate down the tree.
+  final FocusNode focusNode;
+
+  /// Creates a new [FocusMarker].
+  const FocusMarker({required this.focusNode, required super.child});
+
+  @override
+  bool updateShouldNotify(FocusMarker oldWidget) =>
       focusNode != oldWidget.focusNode;
 }

--- a/packages/termui/lib/ui/widgets/horizontal_radio_group.dart
+++ b/packages/termui/lib/ui/widgets/horizontal_radio_group.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:characters/characters.dart';
 import '../color.dart';
 import '../layout.dart';
@@ -6,6 +7,8 @@ import 'text.dart';
 import 'selection_controller.dart';
 import '../../terminal/terminal.dart' as term;
 import 'prompt_runner.dart';
+import 'focus.dart';
+import '../window.dart';
 
 /// A horizontal group of radio-like choices.
 class HorizontalRadioGroup extends StatefulWidget implements Focusable {
@@ -31,6 +34,7 @@ class HorizontalRadioGroup extends StatefulWidget implements Focusable {
 class HorizontalRadioGroupState extends State<HorizontalRadioGroup>
     implements KeyEventHandler {
   SelectionController<String>? _listenedController;
+  late FocusNode _focusNode;
 
   void _onControllerChanged() {
     setState(() {});
@@ -47,12 +51,32 @@ class HorizontalRadioGroupState extends State<HorizontalRadioGroup>
   @override
   void initState() {
     super.initState();
+    _focusNode = FocusNode(id: 'horizontal_radio_group_${widget.hashCode}');
     _updateListener();
+    if (widget.focused) {
+      scheduleMicrotask(() {
+        if (mounted) _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(HorizontalRadioGroup oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _updateListener();
+    if (widget.focused != oldWidget.focused) {
+      if (widget.focused) {
+        _focusNode.requestFocus();
+      } else {
+        _focusNode.unfocus();
+      }
+    }
   }
 
   @override
   void dispose() {
     _listenedController?.removeListener(_onControllerChanged);
+    _focusNode.dispose();
     super.dispose();
   }
 
@@ -99,7 +123,9 @@ class HorizontalRadioGroupState extends State<HorizontalRadioGroup>
       }
       final option = controller.options[i];
       final isSelected = (controller.selectedIndex == i);
-      final isFocused = widget.focused && (controller.focusedIndex == i);
+      final isFocused =
+          (_focusNode.hasFocus || widget.focused) &&
+          (controller.focusedIndex == i);
 
       final box = isSelected ? '[X]' : '[ ]';
       final text = '$box $option';
@@ -121,6 +147,15 @@ class HorizontalRadioGroupState extends State<HorizontalRadioGroup>
       );
     }
 
-    return Row(optionWidgets);
+    return Focus(
+      focusNode: _focusNode,
+      onFocusChange: (hasFocus) {
+        setState(() {});
+      },
+      onKeyEvent: (event) {
+        return handleKeyEvent(event);
+      },
+      child: Row(optionWidgets),
+    );
   }
 }

--- a/packages/termui/lib/ui/widgets/interactive_widgets.dart
+++ b/packages/termui/lib/ui/widgets/interactive_widgets.dart
@@ -1,40 +1,15 @@
+import 'dart:async';
 import '../buffer.dart';
 import '../layout.dart';
 import '../style.dart';
 import '../event.dart' hide Modifier;
 import '../../terminal/terminal.dart' as term;
 import 'prompt_runner.dart';
+import 'focus.dart';
+import '../window.dart';
 
 /// An interactive TUI button widget that triggers a callback when activated.
-///
-/// ### Interfaces
-/// - **Keyboard**: When [focused] is true, pressing Space (`' '`), Enter
-///   (`'\n'`), or Carriage Return (`'\r'`) will trigger [onPressed].
-/// - **Mouse**: Left-clicking (mouse press event) inside the bounds of the
-///   button triggers [onPressed].
-///
-/// ### Example Usage
-///
-/// ```dart
-/// Button(
-///   text: 'Submit',
-///   focused: true,
-///   onPressed: () {
-///     print('Button clicked!');
-///   },
-/// );
-/// ```
-///
-/// ### Properties and Styling
-///
-/// | Property | Type | Description |
-/// | :--- | :--- | :--- |
-/// | `text` | [String] | Label displayed on the button. |
-/// | `onPressed` | `void Function()` | Callback executed when activated. |
-/// | `focused` | [bool] | Whether this button currently has keyboard focus. |
-/// | `style` | [Style] | Normal rendering style. |
-/// | `focusedStyle` | [Style] | Rendering style applied when [focused] is true. |
-class Button extends Widget implements Focusable, KeyEventHandler {
+class Button extends StatefulWidget implements Focusable, KeyEventHandler {
   /// The text label displayed on the button.
   final String text;
 
@@ -52,12 +27,122 @@ class Button extends Widget implements Focusable, KeyEventHandler {
   final Style focusedStyle;
 
   /// Creates a new [Button].
-  const Button({
+  Button({
+    super.key,
     required this.text,
     required this.onPressed,
     this.focused = false,
     this.style = Style.empty,
     this.focusedStyle = const Style(modifiers: Modifier.reverse),
+  });
+
+  // ignore: must_be_immutable
+  ButtonState? _state;
+
+  @override
+  bool handleKeyEvent(term.KeyEvent event) {
+    final hasFocus = focused || (_state?._focusNode.hasFocus ?? false);
+    if (hasFocus &&
+        (event.key == ' ' || event.key == '\n' || event.key == '\r')) {
+      onPressed();
+      _state?.setState(() {});
+      return true;
+    }
+    return false;
+  }
+
+  /// Delegated mouse event handler.
+  void handleMouseEvent(MouseEvent event, int localX, int localY) {
+    if (event.type == MouseEventType.press) {
+      onPressed();
+      _state?.setState(() {});
+    }
+  }
+
+  @override
+  State<Button> createState() {
+    final state = ButtonState();
+    _state = state;
+    return state;
+  }
+}
+
+/// The state for a [Button] widget.
+class ButtonState extends State<Button> implements KeyEventHandler {
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    widget._state = this;
+    _focusNode = FocusNode(id: 'button_${widget.hashCode}');
+    if (widget.focused) {
+      scheduleMicrotask(() {
+        if (mounted) _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(Button oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    widget._state = this;
+    if (widget.focused != oldWidget.focused) {
+      if (widget.focused) {
+        _focusNode.requestFocus();
+      } else {
+        _focusNode.unfocus();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  /// Handles mouse events for the button.
+  void handleMouseEvent(MouseEvent event, int localX, int localY) {
+    widget.handleMouseEvent(event, localX, localY);
+  }
+
+  @override
+  bool handleKeyEvent(term.KeyEvent event) {
+    return widget.handleKeyEvent(event);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _focusNode,
+      onFocusChange: (hasFocus) {
+        setState(() {});
+      },
+      onKeyEvent: (event) {
+        return handleKeyEvent(event);
+      },
+      child: _ButtonRenderWidget(
+        text: widget.text,
+        focused: _focusNode.hasFocus || widget.focused,
+        style: widget.style,
+        focusedStyle: widget.focusedStyle,
+      ),
+    );
+  }
+}
+
+class _ButtonRenderWidget extends Widget {
+  final String text;
+  final bool focused;
+  final Style style;
+  final Style focusedStyle;
+
+  const _ButtonRenderWidget({
+    required this.text,
+    required this.focused,
+    required this.style,
+    required this.focusedStyle,
   });
 
   @override
@@ -66,56 +151,10 @@ class Button extends Widget implements Focusable, KeyEventHandler {
     final label = focused ? '[ $text ]' : '  $text  ';
     buffer.writeString(0, 0, label, focused ? focusedStyle : style);
   }
-
-  /// Handles key activations (Space or Enter).
-  @override
-  bool handleKeyEvent(term.KeyEvent event) {
-    if (focused &&
-        (event.key == ' ' || event.key == '\n' || event.key == '\r')) {
-      onPressed();
-      return true;
-    }
-    return false;
-  }
-
-  /// Handles mouse clicks.
-  void handleMouseEvent(MouseEvent event, int localX, int localY) {
-    if (event.type == MouseEventType.press) {
-      onPressed();
-    }
-  }
 }
 
-/// An interactive checkbox widget for toggling boolean flags.
-///
-/// ### Interfaces
-/// - **Keyboard**: When [focused] is true, pressing Space (`' '`), Enter
-///   (`'\n'`), or Carriage Return (`'\r'`) toggles [value] and triggers [onChanged].
-/// - **Mouse**: Left-clicking inside bounds toggles [value] and triggers [onChanged].
-///
-/// ### Example Usage
-///
-/// ```dart
-/// Checkbox(
-///   value: isAgreed,
-///   label: 'I agree to the terms',
-///   onChanged: (val) {
-///     setState(() => isAgreed = val);
-///   },
-/// );
-/// ```
-///
-/// ### Properties and Styling
-///
-/// | Property | Type | Description |
-/// | :--- | :--- | :--- |
-/// | `value` | [bool] | Current check state (checked if true). |
-/// | `label` | [String] | Descriptive text label next to the checkbox. |
-/// | `onChanged` | `Function(bool)` | Callback triggered when state toggles. |
-/// | `focused` | [bool] | Whether the widget has keyboard focus. |
-/// | `style` | [Style] | Normal rendering style. |
-/// | `focusedStyle` | [Style] | Style applied when [focused] is true. |
-class Checkbox extends Widget implements Focusable, KeyEventHandler {
+/// An interactive checkbox widget supporting toggled true/false options.
+class Checkbox extends StatefulWidget implements Focusable, KeyEventHandler {
   /// The current check state (checked if true).
   final bool value;
 
@@ -136,7 +175,8 @@ class Checkbox extends Widget implements Focusable, KeyEventHandler {
   final Style focusedStyle;
 
   /// Creates a new [Checkbox].
-  const Checkbox({
+  Checkbox({
+    super.key,
     required this.value,
     required this.label,
     required this.onChanged,
@@ -145,64 +185,128 @@ class Checkbox extends Widget implements Focusable, KeyEventHandler {
     this.focusedStyle = const Style(modifiers: Modifier.reverse),
   });
 
+  // ignore: must_be_immutable
+  CheckboxState? _state;
+
+  @override
+  bool handleKeyEvent(term.KeyEvent event) {
+    final hasFocus = focused || (_state?._focusNode.hasFocus ?? false);
+    if (hasFocus &&
+        (event.key == ' ' || event.key == '\n' || event.key == '\r')) {
+      onChanged(!value);
+      _state?.setState(() {});
+      return true;
+    }
+    return false;
+  }
+
+  /// Delegated mouse event handler.
+  void handleMouseEvent(MouseEvent event, int localX, int localY) {
+    if (event.type == MouseEventType.press) {
+      onChanged(!value);
+      _state?.setState(() {});
+    }
+  }
+
+  @override
+  State<Checkbox> createState() {
+    final state = CheckboxState();
+    _state = state;
+    return state;
+  }
+}
+
+/// The state for a [Checkbox] widget.
+class CheckboxState extends State<Checkbox> implements KeyEventHandler {
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    widget._state = this;
+    _focusNode = FocusNode(id: 'checkbox_${widget.hashCode}');
+    if (widget.focused) {
+      scheduleMicrotask(() {
+        if (mounted) _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(Checkbox oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    widget._state = this;
+    if (widget.focused != oldWidget.focused) {
+      if (widget.focused) {
+        _focusNode.requestFocus();
+      } else {
+        _focusNode.unfocus();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  /// Handles mouse events for the checkbox.
+  void handleMouseEvent(MouseEvent event, int localX, int localY) {
+    widget.handleMouseEvent(event, localX, localY);
+  }
+
+  @override
+  bool handleKeyEvent(term.KeyEvent event) {
+    return widget.handleKeyEvent(event);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _focusNode,
+      onFocusChange: (hasFocus) {
+        setState(() {});
+      },
+      onKeyEvent: (event) {
+        return handleKeyEvent(event);
+      },
+      child: _CheckboxRenderWidget(
+        value: widget.value,
+        label: widget.label,
+        focused: _focusNode.hasFocus || widget.focused,
+        style: widget.style,
+        focusedStyle: widget.focusedStyle,
+      ),
+    );
+  }
+}
+
+class _CheckboxRenderWidget extends Widget {
+  final bool value;
+  final String label;
+  final bool focused;
+  final Style style;
+  final Style focusedStyle;
+
+  const _CheckboxRenderWidget({
+    required this.value,
+    required this.label,
+    required this.focused,
+    required this.style,
+    required this.focusedStyle,
+  });
+
   @override
   void render(Buffer buffer, Rect area) {
     if (area.width <= 0 || area.height <= 0) return;
     final box = value ? '[X]' : '[ ]';
     buffer.writeString(0, 0, '$box $label', focused ? focusedStyle : style);
   }
-
-  /// Handles key activations (Space or Enter).
-  @override
-  bool handleKeyEvent(term.KeyEvent event) {
-    if (focused &&
-        (event.key == ' ' || event.key == '\n' || event.key == '\r')) {
-      onChanged(!value);
-      return true;
-    }
-    return false;
-  }
-
-  /// Handles mouse clicks.
-  void handleMouseEvent(MouseEvent event, int localX, int localY) {
-    if (event.type == MouseEventType.press) {
-      onChanged(!value);
-    }
-  }
 }
 
 /// An interactive radio button widget to select a single value from a group.
-///
-/// ### Interfaces
-/// - **Keyboard**: When [focused] is true, pressing Space (`' '`), Enter
-///   (`'\n'`), or Carriage Return (`'\r'`) selects [value] and triggers [onChanged].
-/// - **Mouse**: Left-clicking inside bounds selects [value] and triggers [onChanged].
-///
-/// ### Example Usage
-///
-/// ```dart
-/// Radio<ThemeMode>(
-///   value: ThemeMode.dark,
-///   groupValue: activeTheme,
-///   label: 'Dark Mode',
-///   onChanged: (ThemeMode val) {
-///     setState(() => activeTheme = val);
-///   },
-/// );
-/// ```
-///
-/// ### Properties and Styling
-///
-/// | Property | Type | Description |
-/// | :--- | :--- | :--- |
-/// | `value` | `T` | The specific value represented by this radio button. |
-/// | `groupValue` | `T` | The currently selected value of the radio group. |
-/// | `label` | [String] | Descriptive label text next to the radio circle. |
-/// | `onChanged` | `Function(T)` | Callback triggered when this option is selected. |
-/// | `focused` | [bool] | Whether the widget has keyboard focus. |
-/// | `style` | [Style] | Normal rendering style. |
-/// | `focusedStyle` | [Style] | Style applied when [focused] is true. |
-class Radio<T> extends Widget implements Focusable, KeyEventHandler {
+class Radio<T> extends StatefulWidget implements Focusable, KeyEventHandler {
   /// The specific value represented by this radio button.
   final T value;
 
@@ -226,7 +330,8 @@ class Radio<T> extends Widget implements Focusable, KeyEventHandler {
   final Style focusedStyle;
 
   /// Creates a new [Radio].
-  const Radio({
+  Radio({
+    super.key,
     required this.value,
     required this.groupValue,
     required this.label,
@@ -236,8 +341,120 @@ class Radio<T> extends Widget implements Focusable, KeyEventHandler {
     this.focusedStyle = const Style(modifiers: Modifier.reverse),
   });
 
+  // ignore: must_be_immutable
+  RadioState<T>? _state;
+
+  @override
+  bool handleKeyEvent(term.KeyEvent event) {
+    final hasFocus = focused || (_state?._focusNode.hasFocus ?? false);
+    if (hasFocus &&
+        (event.key == ' ' || event.key == '\n' || event.key == '\r')) {
+      onChanged(value);
+      _state?.setState(() {});
+      return true;
+    }
+    return false;
+  }
+
+  /// Delegated mouse event handler.
+  void handleMouseEvent(MouseEvent event, int localX, int localY) {
+    if (event.type == MouseEventType.press) {
+      onChanged(value);
+      _state?.setState(() {});
+    }
+  }
+
+  @override
+  State<Radio<T>> createState() {
+    final state = RadioState<T>();
+    _state = state;
+    return state;
+  }
+}
+
+/// The state for a [Radio] widget.
+class RadioState<T> extends State<Radio<T>> implements KeyEventHandler {
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    widget._state = this;
+    _focusNode = FocusNode(id: 'radio_${widget.hashCode}');
+    if (widget.focused) {
+      scheduleMicrotask(() {
+        if (mounted) _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(Radio<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    widget._state = this;
+    if (widget.focused != oldWidget.focused) {
+      if (widget.focused) {
+        _focusNode.requestFocus();
+      } else {
+        _focusNode.unfocus();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
   /// Whether this radio button is currently selected.
-  bool get isSelected => value == groupValue;
+  bool get isSelected => widget.value == widget.groupValue;
+
+  /// Handles mouse events for the radio button.
+  void handleMouseEvent(MouseEvent event, int localX, int localY) {
+    widget.handleMouseEvent(event, localX, localY);
+  }
+
+  @override
+  bool handleKeyEvent(term.KeyEvent event) {
+    return widget.handleKeyEvent(event);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _focusNode,
+      onFocusChange: (hasFocus) {
+        setState(() {});
+      },
+      onKeyEvent: (event) {
+        return handleKeyEvent(event);
+      },
+      child: _RadioRenderWidget(
+        isSelected: isSelected,
+        label: widget.label,
+        focused: _focusNode.hasFocus || widget.focused,
+        style: widget.style,
+        focusedStyle: widget.focusedStyle,
+      ),
+    );
+  }
+}
+
+class _RadioRenderWidget extends Widget {
+  final bool isSelected;
+  final String label;
+  final bool focused;
+  final Style style;
+  final Style focusedStyle;
+
+  const _RadioRenderWidget({
+    required this.isSelected,
+    required this.label,
+    required this.focused,
+    required this.style,
+    required this.focusedStyle,
+  });
 
   @override
   void render(Buffer buffer, Rect area) {
@@ -245,56 +462,10 @@ class Radio<T> extends Widget implements Focusable, KeyEventHandler {
     final marker = isSelected ? '(*)' : '( )';
     buffer.writeString(0, 0, '$marker $label', focused ? focusedStyle : style);
   }
-
-  /// Handles key activations (Space or Enter).
-  @override
-  bool handleKeyEvent(term.KeyEvent event) {
-    if (focused &&
-        (event.key == ' ' || event.key == '\n' || event.key == '\r')) {
-      onChanged(value);
-      return true;
-    }
-    return false;
-  }
-
-  /// Handles mouse clicks.
-  void handleMouseEvent(MouseEvent event, int localX, int localY) {
-    if (event.type == MouseEventType.press) {
-      onChanged(value);
-    }
-  }
 }
 
 /// An interactive visual switch toggle widget representing true/false state.
-///
-/// ### Interfaces
-/// - **Keyboard**: When [focused] is true, pressing Space (`' '`), Enter
-///   (`'\n'`), or Carriage Return (`'\r'`) toggles [value] and triggers [onChanged].
-/// - **Mouse**: Left-clicking inside bounds toggles [value] and triggers [onChanged].
-///
-/// ### Example Usage
-///
-/// ```dart
-/// Switch(
-///   value: isNotificationsEnabled,
-///   label: 'Enable Notifications',
-///   onChanged: (val) {
-///     setState(() => isNotificationsEnabled = val);
-///   },
-/// );
-/// ```
-///
-/// ### Properties and Styling
-///
-/// | Property | Type | Description |
-/// | :--- | :--- | :--- |
-/// | `value` | [bool] | The switch toggle state (on/off). |
-/// | `label` | [String] | The text label accompanying the switch. |
-/// | `onChanged` | `Function(bool)` | Callback triggered when the state changes. |
-/// | `focused` | [bool] | Whether this switch has focus. |
-/// | `style` | [Style] | Normal rendering style. |
-/// | `focusedStyle` | [Style] | Style applied when [focused] is true. |
-class Switch extends Widget implements Focusable, KeyEventHandler {
+class Switch extends StatefulWidget implements Focusable, KeyEventHandler {
   /// The switch toggle state (on/off).
   final bool value;
 
@@ -315,7 +486,8 @@ class Switch extends Widget implements Focusable, KeyEventHandler {
   final Style focusedStyle;
 
   /// Creates a new [Switch].
-  const Switch({
+  Switch({
+    super.key,
     required this.value,
     required this.label,
     required this.onChanged,
@@ -324,28 +496,122 @@ class Switch extends Widget implements Focusable, KeyEventHandler {
     this.focusedStyle = const Style(modifiers: Modifier.reverse),
   });
 
-  @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
-    final marker = value ? '[─●]' : '[○─]';
-    buffer.writeString(0, 0, '$marker $label', focused ? focusedStyle : style);
-  }
+  // ignore: must_be_immutable
+  SwitchState? _state;
 
-  /// Handles key activations (Space or Enter).
   @override
   bool handleKeyEvent(term.KeyEvent event) {
-    if (focused &&
+    final hasFocus = focused || (_state?._focusNode.hasFocus ?? false);
+    if (hasFocus &&
         (event.key == ' ' || event.key == '\n' || event.key == '\r')) {
       onChanged(!value);
+      _state?.setState(() {});
       return true;
     }
     return false;
   }
 
-  /// Handles mouse clicks.
+  /// Delegated mouse event handler.
   void handleMouseEvent(MouseEvent event, int localX, int localY) {
     if (event.type == MouseEventType.press) {
       onChanged(!value);
+      _state?.setState(() {});
     }
+  }
+
+  @override
+  State<Switch> createState() {
+    final state = SwitchState();
+    _state = state;
+    return state;
+  }
+}
+
+/// The state for a [Switch] widget.
+class SwitchState extends State<Switch> implements KeyEventHandler {
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    widget._state = this;
+    _focusNode = FocusNode(id: 'switch_${widget.hashCode}');
+    if (widget.focused) {
+      scheduleMicrotask(() {
+        if (mounted) _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(Switch oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    widget._state = this;
+    if (widget.focused != oldWidget.focused) {
+      if (widget.focused) {
+        _focusNode.requestFocus();
+      } else {
+        _focusNode.unfocus();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  /// Handles mouse events for the switch.
+  void handleMouseEvent(MouseEvent event, int localX, int localY) {
+    widget.handleMouseEvent(event, localX, localY);
+  }
+
+  @override
+  bool handleKeyEvent(term.KeyEvent event) {
+    return widget.handleKeyEvent(event);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _focusNode,
+      onFocusChange: (hasFocus) {
+        setState(() {});
+      },
+      onKeyEvent: (event) {
+        return handleKeyEvent(event);
+      },
+      child: _SwitchRenderWidget(
+        value: widget.value,
+        label: widget.label,
+        focused: _focusNode.hasFocus || widget.focused,
+        style: widget.style,
+        focusedStyle: widget.focusedStyle,
+      ),
+    );
+  }
+}
+
+class _SwitchRenderWidget extends Widget {
+  final bool value;
+  final String label;
+  final bool focused;
+  final Style style;
+  final Style focusedStyle;
+
+  const _SwitchRenderWidget({
+    required this.value,
+    required this.label,
+    required this.focused,
+    required this.style,
+    required this.focusedStyle,
+  });
+
+  @override
+  void render(Buffer buffer, Rect area) {
+    if (area.width <= 0 || area.height <= 0) return;
+    final marker = value ? '[─●]' : '[○─]';
+    buffer.writeString(0, 0, '$marker $label', focused ? focusedStyle : style);
   }
 }

--- a/packages/termui/lib/ui/widgets/overlay.dart
+++ b/packages/termui/lib/ui/widgets/overlay.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 import '../buffer.dart';
 import '../layout.dart';
@@ -6,6 +7,8 @@ import '../event.dart' hide Modifier;
 import 'text.dart';
 import '../../terminal/terminal.dart' as term;
 import 'prompt_runner.dart';
+import 'focus.dart';
+import '../window.dart';
 
 /// A function that builds a widget given a build context.
 typedef WidgetBuilder = Widget Function(BuildContext context);
@@ -233,6 +236,31 @@ class DropdownButtonState<T> extends State<DropdownButton<T>>
   /// The index of the currently selected or highlighted item.
   int selectedIndex = 0;
 
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode(id: 'dropdown_${widget.hashCode}');
+    if (widget.focused) {
+      scheduleMicrotask(() {
+        if (mounted) _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(DropdownButton<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.focused != oldWidget.focused) {
+      if (widget.focused) {
+        _focusNode.requestFocus();
+      } else {
+        _focusNode.unfocus();
+      }
+    }
+  }
+
   /// The on-screen bounds of the dropdown button.
   Rect buttonBounds = const Rect(0, 0, 0, 0);
 
@@ -309,6 +337,7 @@ class DropdownButtonState<T> extends State<DropdownButton<T>>
 
   @override
   void dispose() {
+    _focusNode.dispose();
     overlayEntry?.remove();
     super.dispose();
   }
@@ -362,21 +391,30 @@ class DropdownButtonState<T> extends State<DropdownButton<T>>
         ? currentItem.child
         : (widget.hint ?? const Text('Select...'));
 
-    return _DropdownButtonRenderWidget(
-      displayWidget: displayWidget,
-      isOpen: isOpen,
-      focused: widget.focused,
-      style: widget.style,
-      onRender: (bounds) {
-        if (buttonBounds != bounds) {
-          buttonBounds = bounds;
-          if (isOpen && overlayEntry != null) {
-            overlayEntry?._overlayState?.setState(() {});
-          }
-        }
+    return Focus(
+      focusNode: _focusNode,
+      onFocusChange: (hasFocus) {
+        setState(() {});
       },
-      onAction: toggleDropdown,
-      onKey: handleKeyEvent,
+      onKeyEvent: (event) {
+        return handleKeyEvent(event);
+      },
+      child: _DropdownButtonRenderWidget(
+        displayWidget: displayWidget,
+        isOpen: isOpen,
+        focused: _focusNode.hasFocus || widget.focused,
+        style: widget.style,
+        onRender: (bounds) {
+          if (buttonBounds != bounds) {
+            buttonBounds = bounds;
+            if (isOpen && overlayEntry != null) {
+              overlayEntry?._overlayState?.setState(() {});
+            }
+          }
+        },
+        onAction: toggleDropdown,
+        onKey: handleKeyEvent,
+      ),
     );
   }
 }
@@ -595,6 +633,31 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>>
   /// The index of the currently highlighted menu item.
   int selectedIndex = 0;
 
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode(id: 'popup_${widget.hashCode}');
+    if (widget.focused) {
+      scheduleMicrotask(() {
+        if (mounted) _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(PopupMenuButton<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.focused != oldWidget.focused) {
+      if (widget.focused) {
+        _focusNode.requestFocus();
+      } else {
+        _focusNode.unfocus();
+      }
+    }
+  }
+
   /// The on-screen bounds of the trigger button.
   Rect buttonBounds = const Rect(0, 0, 0, 0);
 
@@ -664,6 +727,7 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>>
 
   @override
   void dispose() {
+    _focusNode.dispose();
     overlayEntry?.remove();
     super.dispose();
   }
@@ -705,21 +769,30 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>>
 
   @override
   Widget build(BuildContext context) {
-    return _DropdownButtonRenderWidget(
-      displayWidget: widget.child,
-      isOpen: isOpen,
-      focused: widget.focused,
-      style: Style.empty,
-      onRender: (bounds) {
-        if (buttonBounds != bounds) {
-          buttonBounds = bounds;
-          if (isOpen && overlayEntry != null) {
-            overlayEntry?._overlayState?.setState(() {});
-          }
-        }
+    return Focus(
+      focusNode: _focusNode,
+      onFocusChange: (hasFocus) {
+        setState(() {});
       },
-      onAction: toggleMenu,
-      onKey: handleKeyEvent,
+      onKeyEvent: (event) {
+        return handleKeyEvent(event);
+      },
+      child: _DropdownButtonRenderWidget(
+        displayWidget: widget.child,
+        isOpen: isOpen,
+        focused: _focusNode.hasFocus || widget.focused,
+        style: Style.empty,
+        onRender: (bounds) {
+          if (buttonBounds != bounds) {
+            buttonBounds = bounds;
+            if (isOpen && overlayEntry != null) {
+              overlayEntry?._overlayState?.setState(() {});
+            }
+          }
+        },
+        onAction: toggleMenu,
+        onKey: handleKeyEvent,
+      ),
     );
   }
 }

--- a/packages/termui/lib/ui/widgets/prompt_runner.dart
+++ b/packages/termui/lib/ui/widgets/prompt_runner.dart
@@ -3,6 +3,8 @@ import '../../terminal/terminal.dart' as term;
 import '../buffer.dart';
 import '../layout.dart';
 import '../renderer.dart';
+import 'focus.dart';
+import '../window.dart';
 
 /// An interface that indicates a widget or state can receive keyboard focus.
 abstract interface class Focusable {
@@ -240,7 +242,7 @@ class PromptRunner<T> {
           comp.complete(result as T?);
         }
       },
-      child: widget,
+      child: FocusScope(autofocus: true, child: widget),
     );
 
     // Mount the widget tree element persistently so states and focus configuration
@@ -323,6 +325,13 @@ class PromptRunner<T> {
 
   /// Recursively walks the element tree to find the focused element and route the key event.
   bool _routeKeyEvent(Element element, term.KeyEvent event) {
+    final primaryFocus = FocusManager.instance.primaryFocus;
+    if (primaryFocus != null) {
+      if (primaryFocus.bubbleKeyEvent(event)) {
+        return true;
+      }
+    }
+
     final elWidget = element.widget;
     bool isFocused = false;
     if (elWidget is Focusable) {

--- a/packages/termui/lib/ui/widgets/slider.dart
+++ b/packages/termui/lib/ui/widgets/slider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import '../buffer.dart';
 import '../color.dart';
 import '../event.dart' hide Modifier;
@@ -5,6 +6,8 @@ import '../layout.dart';
 import '../style.dart';
 import '../../terminal/terminal.dart' as term;
 import 'prompt_runner.dart';
+import 'focus.dart';
+import '../window.dart';
 
 /// The orientation of the slider.
 enum SliderAxis {
@@ -16,7 +19,7 @@ enum SliderAxis {
 }
 
 /// A widget for selecting a numeric value by sliding a thumb along a track.
-class Slider extends Widget implements Focusable, KeyEventHandler {
+class Slider extends StatefulWidget implements Focusable, KeyEventHandler {
   /// Whether the slider is focused.
   @override
   final bool focused;
@@ -50,6 +53,7 @@ class Slider extends Widget implements Focusable, KeyEventHandler {
 
   /// Creates a slider.
   Slider({
+    super.key,
     required this.value,
     required this.min,
     required this.max,
@@ -62,21 +66,77 @@ class Slider extends Widget implements Focusable, KeyEventHandler {
     this.onChanged,
   });
 
+  // ignore: must_be_immutable
+  SliderState? _state;
+
+  @override
+  bool handleKeyEvent(term.KeyEvent event) {
+    return _state?.handleKeyEvent(event) ?? false;
+  }
+
   /// Handles mouse events for dragging the slider thumb.
+  void handleMouseEvent(MouseEvent event, int localX, int localY, Rect area) {
+    _state?.handleMouseEvent(event, localX, localY, area);
+  }
+
+  @override
+  State<Slider> createState() {
+    final state = SliderState();
+    _state = state;
+    return state;
+  }
+}
+
+/// The state for a [Slider] widget.
+class SliderState extends State<Slider> implements KeyEventHandler {
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    widget._state = this;
+    _focusNode = FocusNode(id: 'slider_${widget.hashCode}');
+    if (widget.focused) {
+      scheduleMicrotask(() {
+        if (mounted) _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(Slider oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    widget._state = this;
+    if (widget.focused != oldWidget.focused) {
+      if (widget.focused) {
+        _focusNode.requestFocus();
+      } else {
+        _focusNode.unfocus();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  /// Handles mouse events to update the slider's value on drag or click.
   void handleMouseEvent(MouseEvent event, int localX, int localY, Rect area) {
     if (event.type != MouseEventType.press &&
         event.type != MouseEventType.drag) {
       return;
     }
 
-    if (axis == SliderAxis.horizontal) {
+    if (widget.axis == SliderAxis.horizontal) {
       if (localY != 0) return;
       final trackLength = area.width;
       if (trackLength <= 1) return;
 
       final percent = (localX / (trackLength - 1)).clamp(0.0, 1.0);
-      value = min + percent * (max - min);
-      onChanged?.call(value);
+      widget.value = widget.min + percent * (widget.max - widget.min);
+      widget.onChanged?.call(widget.value);
     } else {
       if (localX != 0) return;
       final trackLength = area.height;
@@ -84,33 +144,33 @@ class Slider extends Widget implements Focusable, KeyEventHandler {
 
       // For vertical slider, top (y=0) is max, bottom (y=height-1) is min
       final percent = 1.0 - (localY / (trackLength - 1)).clamp(0.0, 1.0);
-      value = min + percent * (max - min);
-      onChanged?.call(value);
+      widget.value = widget.min + percent * (widget.max - widget.min);
+      widget.onChanged?.call(widget.value);
     }
   }
 
   /// Handles keyboard events for moving the slider.
   @override
   bool handleKeyEvent(term.KeyEvent event) {
-    final step = (max - min) / 20.0; // 5% step size
-    if (axis == SliderAxis.horizontal) {
+    final step = (widget.max - widget.min) / 20.0; // 5% step size
+    if (widget.axis == SliderAxis.horizontal) {
       if (event.type == KeyType.left) {
-        value = (value - step).clamp(min, max);
-        onChanged?.call(value);
+        widget.value = (widget.value - step).clamp(widget.min, widget.max);
+        widget.onChanged?.call(widget.value);
         return true;
       } else if (event.type == KeyType.right) {
-        value = (value + step).clamp(min, max);
-        onChanged?.call(value);
+        widget.value = (widget.value + step).clamp(widget.min, widget.max);
+        widget.onChanged?.call(widget.value);
         return true;
       }
     } else {
       if (event.type == KeyType.up) {
-        value = (value + step).clamp(min, max);
-        onChanged?.call(value);
+        widget.value = (widget.value + step).clamp(widget.min, widget.max);
+        widget.onChanged?.call(widget.value);
         return true;
       } else if (event.type == KeyType.down) {
-        value = (value - step).clamp(min, max);
-        onChanged?.call(value);
+        widget.value = (widget.value - step).clamp(widget.min, widget.max);
+        widget.onChanged?.call(widget.value);
         return true;
       }
     }
@@ -118,20 +178,45 @@ class Slider extends Widget implements Focusable, KeyEventHandler {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final percent = ((value - min) / (max - min)).clamp(0.0, 1.0);
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _focusNode,
+      onFocusChange: (hasFocus) {
+        setState(() {});
+      },
+      onKeyEvent: (event) {
+        return handleKeyEvent(event);
+      },
+      child: _SliderRenderWidget(
+        widget: widget,
+        focused: _focusNode.hasFocus || widget.focused,
+      ),
+    );
+  }
+}
 
-    if (axis == SliderAxis.horizontal) {
+class _SliderRenderWidget extends Widget {
+  final Slider widget;
+  final bool focused;
+
+  const _SliderRenderWidget({required this.widget, required this.focused});
+
+  @override
+  void render(Buffer buffer, Rect area) {
+    final percent = ((widget.value - widget.min) / (widget.max - widget.min))
+        .clamp(0.0, 1.0);
+
+    if (widget.axis == SliderAxis.horizontal) {
       final trackLength = area.width;
       if (trackLength <= 0) return;
       final thumbPos = (percent * (trackLength - 1)).round();
-      final tc = trackChar == '─' ? '─' : trackChar;
+      final tc = widget.trackChar == '─' ? '─' : widget.trackChar;
 
       for (int i = 0; i < trackLength; i++) {
         if (i == thumbPos) {
-          buffer.writeString(i, 0, thumbChar, thumbStyle);
+          buffer.writeString(i, 0, widget.thumbChar, widget.thumbStyle);
         } else {
-          buffer.writeString(i, 0, tc, trackStyle);
+          buffer.writeString(i, 0, tc, widget.trackStyle);
         }
       }
     } else {
@@ -139,13 +224,13 @@ class Slider extends Widget implements Focusable, KeyEventHandler {
       if (trackLength <= 0) return;
       // In terminal, Y=0 is top. For vertical sliders, top is max.
       final thumbPos = trackLength - 1 - (percent * (trackLength - 1)).round();
-      final tc = trackChar == '─' ? '│' : trackChar;
+      final tc = widget.trackChar == '─' ? '│' : widget.trackChar;
 
       for (int i = 0; i < trackLength; i++) {
         if (i == thumbPos) {
-          buffer.writeString(0, i, thumbChar, thumbStyle);
+          buffer.writeString(0, i, widget.thumbChar, widget.thumbStyle);
         } else {
-          buffer.writeString(0, i, tc, trackStyle);
+          buffer.writeString(0, i, tc, widget.trackStyle);
         }
       }
     }

--- a/packages/termui/lib/ui/widgets/text_field.dart
+++ b/packages/termui/lib/ui/widgets/text_field.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 import 'package:characters/characters.dart';
 import '../buffer.dart';
@@ -8,6 +9,8 @@ import '../event.dart' as ev show Modifier;
 import '../color.dart';
 import '../../terminal/terminal.dart' as term;
 import 'prompt_runner.dart';
+import 'focus.dart';
+import '../window.dart';
 
 /// Actions supported by the [TextField] widget.
 enum TextFieldAction {
@@ -831,7 +834,7 @@ class TextField extends StatefulWidget implements Focusable {
   }
 }
 
-/// The state for a [TextField].
+/// The state for a [TextField] widget.
 class TextFieldState extends State<TextField> implements KeyEventHandler {
   @override
   bool handleKeyEvent(term.KeyEvent event) {
@@ -839,6 +842,7 @@ class TextFieldState extends State<TextField> implements KeyEventHandler {
   }
 
   TextEditingController? _listenedController;
+  late FocusNode _focusNode;
 
   void _onControllerChanged() {
     setState(() {});
@@ -855,19 +859,49 @@ class TextFieldState extends State<TextField> implements KeyEventHandler {
   @override
   void initState() {
     super.initState();
+    _focusNode = FocusNode(id: 'textfield_${widget.hashCode}');
     _updateListener();
+    if (widget.focused) {
+      scheduleMicrotask(() {
+        if (mounted) _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(TextField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _updateListener();
+    if (widget.focused != oldWidget.focused) {
+      if (widget.focused) {
+        _focusNode.requestFocus();
+      } else {
+        _focusNode.unfocus();
+      }
+    }
   }
 
   @override
   void dispose() {
     _listenedController?.removeListener(_onControllerChanged);
+    _focusNode.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     _updateListener();
-    return _TextFieldRenderWidget(widget);
+    return Focus(
+      focusNode: _focusNode,
+      onFocusChange: (hasFocus) {
+        widget.focused = hasFocus;
+        setState(() {}); // Redraw cursor highlight
+      },
+      onKeyEvent: (event) {
+        return widget.handleKeyEvent(event);
+      },
+      child: _TextFieldRenderWidget(widget),
+    );
   }
 }
 

--- a/packages/termui/lib/ui/widgets/tree.dart
+++ b/packages/termui/lib/ui/widgets/tree.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:characters/characters.dart';
 import '../buffer.dart';
 import '../style.dart';
@@ -6,6 +7,8 @@ import '../event.dart' hide Modifier;
 import '../color.dart';
 import '../../terminal/terminal.dart' as term;
 import 'prompt_runner.dart';
+import 'focus.dart';
+import '../window.dart';
 
 /// A node in the hierarchical tree structure.
 class TreeNode<T> {
@@ -51,7 +54,7 @@ class FlatNode<T> {
   /// A boolean list representing whether each ancestor of this node is the last child in its respective parent.
   final List<bool> ancestorIsLast;
 
-  /// Creates a [FlatNode] indicating the [node]'s layout [depth] and [ancestorIsLast] info.
+  /// Creates a new [FlatNode] helper.
   FlatNode({
     required this.node,
     required this.depth,
@@ -59,61 +62,9 @@ class FlatNode<T> {
   });
 }
 
-/// An interactive, scrollable tree widget that displays hierarchical node trees.
-///
-/// It supports custom styles for selected, unselected, and branch connector
-/// guide lines.
-///
-/// ### Keyboard Navigation
-/// - **Up Arrow / Down Arrow**: Swaps the selected active node upward or downward
-///   in the flattened tree list.
-/// - **Right Arrow**:
-///   - If the active node is a folder and is collapsed, expands it.
-///   - If the active node is already expanded, moves selection down to its first child.
-/// - **Left Arrow**:
-///   - If the active node is an expanded folder, collapses it.
-///   - If the active node is collapsed or a leaf node, shifts selection back
-///     to its parent folder.
-/// - **Space / Enter**: Triggers the [onSelect] callback with the active node.
-///
-/// ### Example Usage
-///
-/// ```dart
-/// final rootNode = TreeNode(
-///   label: 'Root',
-///   value: 'root_val',
-///   children: [
-///     TreeNode(label: 'Child A', value: 'a_val'),
-///     TreeNode(
-///       label: 'Child B (Folder)',
-///       value: 'b_val',
-///       children: [
-///         TreeNode(label: 'Leaf B1', value: 'b1_val'),
-///       ],
-///     ),
-///   ],
-/// );
-///
-/// TreeWidget(
-///   root: rootNode,
-///   onSelect: (node) {
-///     print('Node chosen: ${node.value}');
-///   },
-/// );
-/// ```
-///
-/// ### Properties and Settings
-///
-/// | Property | Type | Description |
-/// | :--- | :--- | :--- |
-/// | `root` | [TreeNode] | The top-level root node of the tree hierarchy. |
-/// | `onSelect` | `Function(TreeNode)` | Callback executed when a node is activated. |
-/// | `selectedStyle` | [Style] | Style applied to the active selected node line. |
-/// | `unselectedStyle`| [Style] | Style applied to unselected node labels. |
-/// | `lineStyle` | [Style] | Style applied to vertical/horizontal guide lines. |
-/// | `showRoot` | [bool] | Whether to display the root node in the tree list. |
-/// | `focused` | [bool] | Whether this widget currently has focus. |
-class TreeWidget<T> extends Widget implements Focusable, KeyEventHandler {
+/// A tree widget that displays nested TreeNode hierarchies.
+class TreeWidget<T> extends StatefulWidget
+    implements Focusable, KeyEventHandler {
   /// The root node of the tree.
   final TreeNode<T> root;
 
@@ -142,6 +93,7 @@ class TreeWidget<T> extends Widget implements Focusable, KeyEventHandler {
 
   /// Creates a [TreeWidget] with the specified [root] node.
   TreeWidget({
+    super.key,
     required this.root,
     this.onSelect,
     this.selectedStyle = const Style(
@@ -158,21 +110,47 @@ class TreeWidget<T> extends Widget implements Focusable, KeyEventHandler {
   }
 
   /// The index of the currently selected node in the flattened tree.
-  int get selectedIndex => _selectedIndex;
+  int get selectedIndex =>
+      _state != null ? _state!._selectedIndex : _selectedIndex;
 
   /// Sets the index of the currently selected node and clamps it to valid bounds.
   set selectedIndex(int val) {
-    if (_flatNodes.isNotEmpty) {
-      _selectedIndex = val.clamp(0, _flatNodes.length - 1);
+    if (_state != null) {
+      if (_state!._flatNodes.isNotEmpty) {
+        _state!._selectedIndex = val.clamp(0, _state!._flatNodes.length - 1);
+      }
+    } else {
+      if (_flatNodes.isNotEmpty) {
+        _selectedIndex = val.clamp(0, _flatNodes.length - 1);
+      }
+    }
+  }
+
+  /// The scroll offset of the tree.
+  int get scrollOffset =>
+      _state != null ? _state!._scrollOffset : _scrollOffset;
+
+  /// Sets the scroll offset of the tree.
+  set scrollOffset(int val) {
+    if (_state != null) {
+      _state!._scrollOffset = val;
+    } else {
+      _scrollOffset = val;
     }
   }
 
   /// The list of visible flattened nodes in the tree.
-  List<FlatNode<T>> get flatNodes => _flatNodes;
+  List<FlatNode<T>> get flatNodes =>
+      _state != null ? _state!._flatNodes : _flatNodes;
 
   void _updateFlatNodes() {
-    _flatNodes = [];
-    _flatten(root, 0, [], true);
+    if (_state != null) {
+      _state!._flatNodes = [];
+      _flatten(root, 0, [], true, _state!._flatNodes);
+    } else {
+      _flatNodes = [];
+      _flatten(root, 0, [], true, _flatNodes);
+    }
   }
 
   void _flatten(
@@ -180,6 +158,7 @@ class TreeWidget<T> extends Widget implements Focusable, KeyEventHandler {
     int depth,
     List<bool> ancestorIsLast,
     bool isLast,
+    List<FlatNode<T>> target,
   ) {
     final nextAncestorIsLast = List<bool>.from(ancestorIsLast);
     if (depth > 0) {
@@ -187,7 +166,7 @@ class TreeWidget<T> extends Widget implements Focusable, KeyEventHandler {
     }
 
     if (depth > 0 || showRoot) {
-      _flatNodes.add(
+      target.add(
         FlatNode(node: node, depth: depth, ancestorIsLast: nextAncestorIsLast),
       );
     }
@@ -196,94 +175,180 @@ class TreeWidget<T> extends Widget implements Focusable, KeyEventHandler {
       for (var i = 0; i < node.children.length; i++) {
         final child = node.children[i];
         final isLastChild = i == node.children.length - 1;
-        _flatten(child, depth + 1, nextAncestorIsLast, isLastChild);
+        _flatten(child, depth + 1, nextAncestorIsLast, isLastChild, target);
       }
     }
   }
 
-  /// Handles incoming key events for navigation and selection.
+  // ignore: must_be_immutable
+  TreeWidgetState<T>? _state;
+
   @override
   bool handleKeyEvent(term.KeyEvent event) {
-    if (_flatNodes.isEmpty) return false;
+    if (_state != null) {
+      return _state!.handleKeyEvent(event);
+    }
+    return _handleKeyEventInternal(event);
+  }
+
+  bool _handleKeyEventInternal(term.KeyEvent event) {
+    final nodes = flatNodes;
+    if (nodes.isEmpty) return false;
+
+    bool handled = false;
 
     if (event.type == KeyType.up) {
-      _selectedIndex = (_selectedIndex - 1).clamp(0, _flatNodes.length - 1);
-      return true;
+      selectedIndex = selectedIndex - 1;
+      handled = true;
     } else if (event.type == KeyType.down) {
-      _selectedIndex = (_selectedIndex + 1).clamp(0, _flatNodes.length - 1);
-      return true;
+      selectedIndex = selectedIndex + 1;
+      handled = true;
     } else if (event.type == KeyType.right) {
-      final flat = _flatNodes[_selectedIndex];
+      final flat = nodes[selectedIndex];
       if (!flat.node.isLeaf) {
         if (!flat.node.isExpanded) {
           flat.node.isExpanded = true;
           _updateFlatNodes();
         } else {
-          if (_selectedIndex < _flatNodes.length - 1) {
-            _selectedIndex++;
+          if (selectedIndex < nodes.length - 1) {
+            selectedIndex = selectedIndex + 1;
           }
         }
       }
-      return true;
+      handled = true;
     } else if (event.type == KeyType.left) {
-      final flat = _flatNodes[_selectedIndex];
+      final flat = nodes[selectedIndex];
       if (!flat.node.isLeaf && flat.node.isExpanded) {
         flat.node.isExpanded = false;
         _updateFlatNodes();
       } else {
+        // Move to parent
         final parent = flat.node.parent;
         if (parent != null) {
-          final parentIdx = _flatNodes.indexWhere((f) => f.node == parent);
+          final parentIdx = nodes.indexWhere((f) => f.node == parent);
           if (parentIdx != -1) {
-            _selectedIndex = parentIdx;
+            selectedIndex = parentIdx;
           }
         }
       }
-      return true;
+      handled = true;
     } else if (event.key == ' ' || event.type == KeyType.enter) {
       if (onSelect != null) {
-        onSelect!(_flatNodes[_selectedIndex].node);
+        onSelect!(nodes[selectedIndex].node);
       }
-      return true;
+      handled = true;
     }
-    return false;
-  }
 
-  /// Adjusts the scroll offset to keep the selected item visible within the [viewportHeight].
-  void adjustScroll(int viewportHeight) {
-    if (_flatNodes.isEmpty || viewportHeight <= 0) return;
-    _selectedIndex = _selectedIndex.clamp(0, _flatNodes.length - 1);
-
-    if (_selectedIndex < _scrollOffset) {
-      _scrollOffset = _selectedIndex;
-    } else if (_selectedIndex >= _scrollOffset + viewportHeight) {
-      _scrollOffset = _selectedIndex - viewportHeight + 1;
-    }
-    _scrollOffset = _scrollOffset.clamp(
-      0,
-      (_flatNodes.length - viewportHeight).clamp(0, _flatNodes.length),
-    );
+    return handled;
   }
 
   @override
+  State<TreeWidget<T>> createState() {
+    final state = TreeWidgetState<T>();
+    _state = state;
+    return state;
+  }
+}
+
+/// The state for a [TreeWidget] widget.
+class TreeWidgetState<T> extends State<TreeWidget<T>>
+    implements KeyEventHandler {
+  late FocusNode _focusNode;
+  late List<FlatNode<T>> _flatNodes;
+  int _selectedIndex = 0;
+  int _scrollOffset = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedIndex = widget._selectedIndex;
+    _scrollOffset = widget._scrollOffset;
+    widget._state = this;
+    widget._updateFlatNodes();
+    _focusNode = FocusNode(id: 'tree_${widget.hashCode}');
+    if (widget.focused) {
+      scheduleMicrotask(() {
+        if (mounted) _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(TreeWidget<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    widget._state = this;
+    if (widget.focused != oldWidget.focused) {
+      if (widget.focused) {
+        _focusNode.requestFocus();
+      } else {
+        _focusNode.unfocus();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  bool handleKeyEvent(term.KeyEvent event) {
+    final handled = widget._handleKeyEventInternal(event);
+    if (handled) {
+      setState(() {});
+    }
+    return handled;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _focusNode,
+      onFocusChange: (hasFocus) {
+        widget.focused = hasFocus;
+        setState(() {});
+      },
+      onKeyEvent: (event) {
+        return handleKeyEvent(event);
+      },
+      child: _TreeWidgetRenderWidget(
+        widget: widget,
+        focused: _focusNode.hasFocus || widget.focused,
+      ),
+    );
+  }
+}
+
+class _TreeWidgetRenderWidget extends Widget {
+  final TreeWidget widget;
+  final bool focused;
+
+  const _TreeWidgetRenderWidget({required this.widget, required this.focused});
+
+  @override
   void render(Buffer buffer, Rect area) {
-    _updateFlatNodes();
-    adjustScroll(area.height);
+    widget._updateFlatNodes();
+    widget.adjustScroll(area.height);
 
     final activeSelectedStyle = focused
-        ? selectedStyle
+        ? widget.selectedStyle
         : Style(
-            foreground: selectedStyle.foreground,
+            foreground: widget.selectedStyle.foreground,
             background: CharmColors.char,
-            modifiers: selectedStyle.modifiers,
+            modifiers: widget.selectedStyle.modifiers,
           );
 
-    for (var i = 0; i < area.height; i++) {
-      final nodeIdx = _scrollOffset + i;
-      if (nodeIdx >= _flatNodes.length) break;
+    final nodes = widget.flatNodes;
+    final offset = widget.scrollOffset;
+    final selIdx = widget.selectedIndex;
 
-      final flat = _flatNodes[nodeIdx];
-      final isSelected = nodeIdx == _selectedIndex;
+    for (var i = 0; i < area.height; i++) {
+      final nodeIdx = offset + i;
+      if (nodeIdx >= nodes.length) break;
+
+      final flat = nodes[nodeIdx];
+      final isSelected = nodeIdx == selIdx;
 
       var x = 0;
 
@@ -296,7 +361,7 @@ class TreeWidget<T> extends Widget implements Focusable, KeyEventHandler {
           area.x + x,
           area.y + i,
           part,
-          isSelected ? activeSelectedStyle : lineStyle,
+          isSelected ? activeSelectedStyle : widget.lineStyle,
         );
         x += 3;
       }
@@ -309,7 +374,7 @@ class TreeWidget<T> extends Widget implements Focusable, KeyEventHandler {
           area.x + x,
           area.y + i,
           part,
-          isSelected ? activeSelectedStyle : lineStyle,
+          isSelected ? activeSelectedStyle : widget.lineStyle,
         );
         x += 4;
       }
@@ -323,7 +388,7 @@ class TreeWidget<T> extends Widget implements Focusable, KeyEventHandler {
           area.x + x,
           area.y + i,
           indicator,
-          isSelected ? activeSelectedStyle : lineStyle,
+          isSelected ? activeSelectedStyle : widget.lineStyle,
         );
         x += 2;
       }
@@ -340,9 +405,29 @@ class TreeWidget<T> extends Widget implements Focusable, KeyEventHandler {
           area.x + x,
           area.y + i,
           labelText,
-          isSelected ? activeSelectedStyle : unselectedStyle,
+          isSelected ? activeSelectedStyle : widget.unselectedStyle,
         );
       }
     }
+  }
+}
+
+/// Extension to manage scroll offsets for [TreeWidget].
+extension TreeWidgetScrollExtension on TreeWidget {
+  /// Adjusts the scroll offset to keep the selected item visible.
+  void adjustScroll(int viewportHeight) {
+    final nodes = flatNodes;
+    if (nodes.isEmpty || viewportHeight <= 0) return;
+    selectedIndex = selectedIndex.clamp(0, nodes.length - 1);
+
+    if (selectedIndex < scrollOffset) {
+      scrollOffset = selectedIndex;
+    } else if (selectedIndex >= scrollOffset + viewportHeight) {
+      scrollOffset = selectedIndex - viewportHeight + 1;
+    }
+    scrollOffset = scrollOffset.clamp(
+      0,
+      (nodes.length - viewportHeight).clamp(0, nodes.length),
+    );
   }
 }

--- a/packages/termui/lib/ui/window.dart
+++ b/packages/termui/lib/ui/window.dart
@@ -21,131 +21,183 @@ import '../perf/tracer.dart';
 /// | [children] | Direct descendants of this focus node. |
 /// | [onKeyEvent] | Callback to process a key event. Return `true` to stop propagation. |
 /// | [onFocusChange] | Callback executed when focus status transitions. |
+/// Centralized registry managing active focus paths.
+class FocusManager {
+  /// The singleton instance of [FocusManager].
+  static final FocusManager instance = FocusManager._();
+  FocusManager._();
+
+  FocusNode? _primaryFocus;
+
+  /// Returns the currently active focused leaf node in O(1) time.
+  FocusNode? get primaryFocus => _primaryFocus;
+
+  /// Sets focus to [node], updating the focus path to the root.
+  void setPrimaryFocus(FocusNode? node) {
+    if (_primaryFocus == node) return;
+
+    final oldPath = _getPathToRoot(_primaryFocus);
+    final newPath = _getPathToRoot(node);
+
+    // Unfocus nodes no longer on the active path
+    for (final oldNode in oldPath) {
+      if (!newPath.contains(oldNode)) {
+        oldNode._setFocused(false);
+      }
+    }
+
+    // Focus nodes entering the active path
+    for (final newNode in newPath) {
+      if (!oldPath.contains(newNode)) {
+        newNode._setFocused(true);
+      }
+      if (newNode.parent is FocusScopeNode) {
+        (newNode.parent as FocusScopeNode)._focusedChild = newNode;
+      }
+    }
+
+    _primaryFocus = node;
+  }
+
+  List<FocusNode> _getPathToRoot(FocusNode? node) {
+    final path = <FocusNode>[];
+    var current = node;
+    while (current != null) {
+      path.add(current);
+      current = current.parent;
+    }
+    return path;
+  }
+}
+
+/// A representation of a node in the focus tree.
 class FocusNode {
   /// Unique identifier of the focus node (useful for debugging).
   final String id;
 
-  /// Whether this node currently holds keyboard focus.
-  bool isFocused = false;
-
   /// The parent focus node, if any.
   FocusNode? parent;
 
-  /// The child nodes nested under this node.
+  /// The children focus nodes nested under this node.
   final List<FocusNode> children = [];
 
-  /// Callback executed when a key event hits this node.
-  /// Return `true` to consume the keypress and prevent it from bubbling up the tree.
-  bool Function(KeyEvent event)? onKeyEvent;
+  /// Whether this node currently holds focus.
+  bool _isFocused = false;
+
+  /// Whether this node currently has focus.
+  bool get hasFocus => _isFocused;
+
+  /// Whether this node currently holds focus.
+  bool get isFocused => _isFocused;
 
   /// Callback executed when this focus node gains or loses focus.
   void Function(bool hasFocus)? onFocusChange;
 
-  /// Creates a [FocusNode] with the given [id].
+  /// Callback executed when a key event hits this node.
+  /// Return `true` to consume the keypress and prevent it from bubbling.
+  bool Function(KeyEvent event)? onKeyEvent;
+
+  /// Creates a new [FocusNode] with the given [id].
   FocusNode({required this.id});
 
-  /// Whether this node has focus.
-  bool get hasFocus => isFocused;
-
   /// Whether this node has primary focus, meaning it is focused and none of its children are.
-  bool get hasPrimaryFocus => isFocused && children.every((c) => !c.isFocused);
+  bool get hasPrimaryFocus =>
+      _isFocused && children.every((c) => !c._isFocused);
+
+  /// Request focus for this specific node.
+  void requestFocus() {
+    FocusManager.instance.setPrimaryFocus(this);
+  }
+
+  /// Removes focus from this node.
+  void unfocus() {
+    if (hasFocus) {
+      FocusManager.instance.setPrimaryFocus(parent);
+    } else {
+      _setFocused(false);
+    }
+  }
+
+  /// Internal focus state setter. Called by [FocusManager].
+  void _setFocused(bool value) {
+    if (_isFocused == value) return;
+    _isFocused = value;
+    onFocusChange?.call(value);
+  }
 
   /// Adds a child focus node to this branch.
   void addChild(FocusNode child) {
+    if (child.parent == this) return;
+    child.parent?.children.remove(child);
     child.parent = this;
     children.add(child);
+    if (child._isFocused) {
+      FocusNode? current = this;
+      while (current != null) {
+        current._setFocused(true);
+        if (current.parent is FocusScopeNode) {
+          (current.parent as FocusScopeNode)._focusedChild = current;
+        }
+        current = current.parent;
+      }
+    }
   }
 
-  /// Requests focus for this node, unfocusing other sibling branches recursively.
-  void requestFocus() {
-    // 1. Find root
-    var root = this;
-    while (root.parent != null) {
-      root = root.parent!;
+  /// Removes a child focus node from this branch.
+  void removeChild(FocusNode child) {
+    if (child.parent == this) {
+      children.remove(child);
+      child.parent = null;
     }
+  }
 
-    // 2. Unfocus everything under root
-    root._unfocusRecursive();
-
-    // 3. Focus path from this node to root
-    FocusNode? current = this;
+  /// Bubbles the [event] up the parent chain starting from the focused leaf.
+  bool bubbleKeyEvent(KeyEvent event) {
+    FocusNode? current = findFocusedLeaf() ?? this;
     while (current != null) {
-      final wasFocused = current.isFocused;
-      current.isFocused = true;
-      if (!wasFocused) {
-        current.onFocusChange?.call(true);
-      }
-      if (current is FocusScopeNode) {
-        FocusNode? childOnPath;
-        for (final child in current.children) {
-          if (child.isFocused) {
-            childOnPath = child;
-            break;
-          }
-        }
-        if (childOnPath != null) {
-          current._focusedChild = childOnPath;
-        }
+      if (current.onKeyEvent != null && current.onKeyEvent!(event)) {
+        return true; // Consumed
       }
       current = current.parent;
     }
-  }
-
-  /// Removes focus from this node and its descendants.
-  void unfocus() {
-    if (!isFocused) return;
-    _unfocusRecursive();
-  }
-
-  void _unfocusRecursive() {
-    final wasFocused = isFocused;
-    isFocused = false;
-    if (wasFocused) {
-      onFocusChange?.call(false);
-    }
-    for (final child in children) {
-      child._unfocusRecursive();
-    }
+    return false; // Propagates to system fallback
   }
 
   /// Traverses down the focused path to find the deeply focused leaf node.
   FocusNode? findFocusedLeaf() {
-    if (!isFocused) return null;
+    if (!_isFocused) return null;
     for (final child in children) {
-      if (child.isFocused) {
+      if (child._isFocused) {
         return child.findFocusedLeaf();
       }
     }
     return this;
   }
 
-  /// Traverses up from the primary focus node to let nodes consume keypresses.
-  bool bubbleKeyEvent(KeyEvent event) {
-    final leaf = findFocusedLeaf();
-    if (leaf != null) {
-      return leaf._bubbleUp(event);
+  /// Disposes of the focus node, detaching it from the tree.
+  void dispose() {
+    if (hasFocus) {
+      FocusNode? nextTarget = parent;
+      if (parent != null) {
+        final siblings = parent!.children.where((c) => c != this).toList();
+        if (siblings.isNotEmpty) {
+          nextTarget = siblings.first;
+        }
+      }
+      FocusManager.instance.setPrimaryFocus(nextTarget);
     }
-    return false;
-  }
-
-  bool _bubbleUp(KeyEvent event) {
-    if (onKeyEvent != null && onKeyEvent!(event)) {
-      return true; // consumed
+    final p = parent;
+    if (p != null) {
+      p.children.remove(this);
+      if (p is FocusScopeNode && p._focusedChild == this) {
+        p._focusedChild = p.children.isNotEmpty ? p.children.first : null;
+      }
+      parent = null;
     }
-    return parent?._bubbleUp(event) ?? false;
   }
 }
 
 /// A specialized focus scope node that manages focus traversal.
-///
-/// Grouping interactive focus nodes inside a [FocusScopeNode] enables cycling focus
-/// among its descendants (e.g. by pressing Tab for forward cycles or Shift-Tab for backward cycles).
-/// It keeps track of the currently active focused child in the scope.
-///
-/// ### Traversal APIs
-///
-/// * [nextFocus()]: Move focus to the next child in [children].
-/// * [previousFocus()]: Move focus to the previous child in [children].
 class FocusScopeNode extends FocusNode {
   FocusNode? _focusedChild;
 
@@ -154,6 +206,16 @@ class FocusScopeNode extends FocusNode {
 
   /// The active focused child node inside this scope.
   FocusNode? get focusedChild => _focusedChild;
+
+  @override
+  void requestFocus() {
+    if (children.isEmpty) {
+      super.requestFocus();
+      return;
+    }
+    final target = _focusedChild ?? children.first;
+    target.requestFocus();
+  }
 
   /// Cycles keyboard focus forward to the next sibling in the scope's focus list.
   void nextFocus() {

--- a/packages/termui/test/prompt_runner_test.dart
+++ b/packages/termui/test/prompt_runner_test.dart
@@ -71,7 +71,9 @@ class MockTerminal extends Terminal {
   }
 }
 
-class TestKeyConsumerWidget extends Widget {
+class TestKeyConsumerWidget extends Widget
+    implements Focusable, KeyEventHandler {
+  @override
   final bool focused;
   final bool shouldConsume;
 
@@ -80,6 +82,7 @@ class TestKeyConsumerWidget extends Widget {
   @override
   void render(Buffer buffer, Rect area) {}
 
+  @override
   bool handleKeyEvent(ui.KeyEvent event) {
     return shouldConsume;
   }

--- a/packages/termui/test/widget_book_test.dart
+++ b/packages/termui/test/widget_book_test.dart
@@ -5,6 +5,7 @@ import 'package:termui/terminal/terminal.dart';
 import 'package:termui/terminal/backend/terminal_backend.dart';
 import 'package:termui/ui/event.dart' as ui;
 import 'package:termui/ui/buffer.dart';
+import 'package:termui/perf/tracer.dart';
 import 'package:termui_shared_examples/widget_book/widget_book_runner.dart';
 import 'package:termui_shared_examples/widget_book/widget_book_platform.dart';
 
@@ -168,5 +169,63 @@ void main() {
         terminal.dispose();
       }
     });
+
+    test(
+      'Focused text field consumes character keys and prevents global hotkeys',
+      () async {
+        final backend = FakeTerminalBackend();
+        final terminal = MockTerminal(backend);
+        final platform = TestWidgetBookPlatform();
+
+        // Run widget book runner
+        final bookFuture = runWidgetBookShared(terminal, platform);
+
+        // Wait for initialization
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        // By default, focusDemoPane is false.
+        // Press Tab to focus the demo pane.
+        terminal.injectTestEvent(const ui.KeyEvent('\t', ui.KeyType.tab));
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        // Now focusDemoPane is true.
+        // Inject a key event like 't' which is a global shortcut to start/stop tracing.
+        terminal.injectTestEvent(const ui.KeyEvent('t', ui.KeyType.character));
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        // If 't' was consumed by the demo pane, Tracer should NOT be enabled.
+        expect(Tracer.isEnabled, isFalse);
+
+        // Inject 'q' key event while focused.
+        // 'q' is a global shortcut to quit. Since we are focused, it should be consumed and NOT quit.
+        terminal.injectTestEvent(const ui.KeyEvent('q', ui.KeyType.character));
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        // We should still be running. Let's verify by checking that the book future hasn't completed.
+        var isCompleted = false;
+        bookFuture.then((_) => isCompleted = true);
+        await Future.delayed(const Duration(milliseconds: 50));
+        expect(isCompleted, isFalse);
+
+        // Now unfocus the demo pane by injecting escape
+        terminal.injectTestEvent(
+          const ui.KeyEvent('\u001b', ui.KeyType.escape),
+        );
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        // Now focusDemoPane should be false.
+        // Injecting 'q' now should exit the runner loop.
+        terminal.injectTestEvent(const ui.KeyEvent('q', ui.KeyType.character));
+
+        await bookFuture.timeout(
+          const Duration(seconds: 2),
+          onTimeout: () => throw TimeoutException(
+            'Widget book did not exit on "q" after unfocusing',
+          ),
+        );
+
+        terminal.dispose();
+      },
+    );
   });
 }

--- a/packages/termui_shared_examples/lib/widget_book/widget_book_runner.dart
+++ b/packages/termui_shared_examples/lib/widget_book/widget_book_runner.dart
@@ -248,6 +248,20 @@ Future<void> runWidgetBookShared(
           break;
         }
 
+        bool consumedByDemoPane = false;
+        if (focusDemoPane) {
+          if (event.type == ui.KeyType.escape) {
+            focusDemoPane = false;
+            continue;
+          }
+
+          consumedByDemoPane = activeExample.handleKeyEvent(event);
+        }
+
+        if (consumedByDemoPane) {
+          continue;
+        }
+
         if (event.type == ui.KeyType.character && event.key == 'q') {
           break;
         }
@@ -276,14 +290,6 @@ Future<void> runWidgetBookShared(
         }
 
         if (focusDemoPane) {
-          if (event.type == ui.KeyType.escape) {
-            focusDemoPane = false;
-            continue;
-          }
-
-          final consumed = activeExample.handleKeyEvent(event);
-          if (consumed) continue;
-
           if (event.type == ui.KeyType.tab &&
               !event.modifiers.contains(ui.Modifier.shift)) {
             focusDemoPane = false;


### PR DESCRIPTION
Introduce a declarative focus management system in termui using Focus and FocusScope widgets. This replaces manual focus tracking on interactive widgets and enables structured key event propagation down the focus tree.

Key changes:
- Implement `Focus`, `FocusScope`, and `FocusMarker` widgets to manage and propagate `FocusNode` instances in the widget tree.
- Add `didUpdateWidget` lifecycle method to `State` and `StatefulElement`.
- Update `FocusNode` and `FocusScopeNode` with `dispose()` clean-up, requestFocus overrides, and a bubbling `bubbleKeyEvent` method.
- Refactor interactive widgets (`Switch`, `DropdownButton`, `PopupMenuButton`, `Slider`, `TextField`, `TreeWidget`) to delegate focus management to the new `Focus` widget.
- Update `PromptRunner` to initialize a root `FocusScope` and bubble key events through `FocusManager.instance.primaryFocus` first.
- Fix key event routing in `widget_book_runner` to prioritize active widget consumption, preventing global hotkey conflicts.
- Configure developer agent rules and add conventional commits skill documentation.