### PR TITLE
refactor(ui)!: transition rendering pipeline to declarative Element-based architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,45 +1,39 @@
-# Developer & AI Agent Handbook: CLI Experiment Windowing System
+# Developer & AI Agent Handbook: CLI Element-based Windowing System
 
-Welcome to the **cli_experiment** codebase. This document serves as a comprehensive system map and developer guide detailing the product vision, tech stack, and internal architecture. Use this guide to understand how components interact, where to make modifications, and how the underlying terminal layout engine operates.
-
----
-
-## 1. Product Overview
-
-The `cli_experiment` project is a modular, performant, double-buffered **Terminal User Interface (TUI)** and **Windowing System** written in Dart. It moves away from naive CLI output printing (which causes terminal flicker and high overhead) and provides a desktop-like environment inside standard ANSI/TTY terminal applications.
-
-### Key Capabilities
-- **Overlapping Window Management**: Supports floating, draggable, and resizeable frames with custom titles, borders, and Z-index layering.
-- **Double Buffering**: Prevents terminal flickering by maintaining an in-memory frame buffer of what is visible on-screen and comparing it with a previous frame to compute delta updates.
-- **Minimal ANSI Diffing**: Emits the shortest possible terminal sequences (cursor jumps and style transitions) to repaint only the modified cells.
-- **Layout Solver**: Flexible constraints layout system featuring fixed size, percentage, flex (proportional), and min-max boundaries.
-- **Hierarchical Input & Focus System**: Translates raw ANSI byte streams from `stdin` into high-level event objects (keys, mouse clicks/scrolls/drags, paste segments) and dispatches them down a keyboard focus node tree.
-- **Modular Widget Toolkit**: Standard widgets including paragraph wrappers, lists, interactive input fields with visual cursors, progress bars, a braille-based grid canvas, tile maps, and menu overlays.
+Welcome to the **cli_experiment** / **termui** codebase. This document serves as a comprehensive developer and AI agent handbook detailing the product vision, core architectures, package layouts, element tree lifecycles, and testing practices.
 
 ---
 
-## 2. Tech Stack
+## 1. Product Overview & System Map
 
-The project runs on the Dart environment and depends on lightweight packages to coordinate raw input parsing and native Windows support:
+`termui` is a high-performance, double-buffered **Terminal User Interface (TUI)** and **Windowing System** written in Dart. It moves away from naive CLI output printing (which causes terminal flicker and high overhead) and provides a desktop-like environment inside standard ANSI/TTY terminal applications.
 
-- **Dart SDK**: `^3.10.0` (utilizes modern Dart collections, record matching, and extensions).
-- **Core Dependencies**:
-  - `dart:ffi`: Crucial for loading platform C libraries (`libc.so.6` or `/usr/lib/libSystem.dylib` on Unix) to configure standard input raw mode, and querying terminal sizes.
-  - [package:win32](file:///app/pubspec.yaml#L17) (`^5.5.4`): Enables native console state manipulation (`SetConsoleMode`, `GetConsoleScreenBufferInfo`) on Windows.
-  - [package:ffi](file:///app/pubspec.yaml#L14) (`^2.1.3`): Allocates C structures and handles pointer conversions for FFI.
-  - [package:characters](file:///app/pubspec.yaml#L12) (`^1.3.0`): Treats user-perceived grapheme clusters correctly (correctly handling multi-byte characters, ZWJ sequences, and emojis).
-  - [package:ansicolor](file:///app/pubspec.yaml#L10) (`^2.0.3`): Utilities for 8-bit color pen styling.
-  - [package:args](file:///app/pubspec.yaml#L11) (`^2.4.2`): Standard CLI command-line arguments parsing.
-  - [package:quiver](file:///app/pubspec.yaml#L15) (`^3.2.2`): Collection and comparison utility helpers.
-- **Development Dependencies**:
-  - [package:test](file:///app/pubspec.yaml#L16) (`^1.25.8`): Framework for running unit and integration tests.
-  - [package:lints](file:///app/pubspec.yaml#L20) (`^6.0.0`): Static analysis and formatting.
+### Core Goals
+* **Overlapping Window Management**: Supports floating, draggable, and resizeable frames with custom titles, borders, and Z-index layering.
+* **Double Buffering**: Prevents terminal flickering by maintaining an in-memory frame buffer of what is visible on-screen and comparing it with a previous frame to compute delta updates.
+* **Minimal ANSI Diffing**: Emits the shortest possible terminal sequences (cursor jumps and style transitions) to repaint only the modified cells.
+* **Element & Widget Tree**: Re-implements a Flutter-like reactive layout system where widgets describe configurations, elements manage tree lifecycles, and states hold stateful properties.
+* **Hierarchical Input & Focus System**: Translates raw ANSI byte streams from `stdin` into high-level event objects (keys, mouse clicks/scrolls/drags, paste segments) and dispatches them down a keyboard focus node tree.
+* **Modular Widget Toolkit**: Standard widgets including paragraph wrappers, lists, interactive input fields with visual cursors, progress bars, a braille-based grid canvas, tile maps, and menu overlays.
 
 ---
 
-## 3. Architecture & Subsystems
+## 2. Monorepo Package Architecture
 
-The system is structured as a series of layered abstractions from the native operating system TTY layer to the user-facing widgets.
+The project is managed as a Melos monorepo with the following workspace packages:
+
+1. **[termui](/packages/termui)** (Core package): Implements the layout engine, widgets, elements, focus management, and ANSI rendering pipeline.
+2. **[termui_shared_examples](/packages/termui_shared_examples)**: Contains example interfaces and reusable scenario layouts.
+3. **[termui_recorder](/packages/termui_recorder)**: Mock terminal recorder framework used for testing and validating rendering behaviors.
+
+### Dependencies & Platforms
+* **Dart SDK**: Target environment is `sdk: ">=3.11.0 <4.0.0"`.
+* **Platform APIs**: Interacts with libc APIs on Linux/Unix using `dart:ffi` and Windows APIs using [win32](/pubspec.yaml#L17) (`^6.0.0`) to configure TTY raw mode and query screen sizing.
+* **Unicode / Wide Characters**: Uses [characters](/pubspec.yaml#L12) (`^1.4.0`) to correctly measure and slice grapheme clusters (correctly handling multi-byte characters, ZWJ sequences, and emojis).
+
+---
+
+## 3. Subsystem Breakdown
 
 ```mermaid
 graph TD
@@ -57,67 +51,105 @@ graph TD
   Renderer -->|Minimal ANSI codes| Terminal
 ```
 
-### A. Terminal Layer (`lib/terminal/`)
+### A. Terminal & TTY Layer
 Responsible for switching terminal input modes, polling window sizes, and handling low-level byte channels.
+* **[Terminal](/packages/termui/lib/terminal/terminal.dart)**: The main entrypoint exposing screen sizing, SIGWINCH size observers (or polling on Windows), and raw input streams.
+* **[UnixTerminal](/packages/termui/lib/terminal/raw/unix_terminal.dart)**: Interacts with libc `tcgetattr` and `tcsetattr` via FFI, disabling terminal echo, canonical processing (`ICANON`), and signal processing (`ISIG`).
+* **[WindowsTerminal](/packages/termui/lib/terminal/raw/windows_terminal.dart)**: Uses FFI to invoke Windows APIs for TTY controls.
 
-- **[Terminal](file:///app/lib/terminal/terminal.dart)**: The main interface exposing screen sizing, SIGWINCH size observers (or polling on Windows), and raw input streams.
-- **[Terminal raw factory](file:///app/lib/terminal/raw/terminal.dart)**: Dispatches implementation classes:
-  - **[UnixTerminal](file:///app/lib/terminal/raw/unix_terminal.dart)**: Interacts with libc `tcgetattr` and `tcsetattr` via FFI, disabling terminal echo, canonical processing (`ICANON`), and signal processing (`ISIG`).
-  - **[WindowsTerminal](file:///app/lib/terminal/raw/windows_terminal.dart)**: Uses FFI to invoke Windows APIs for TTY controls.
+### B. Buffering & Painting
+* **[Cell](/packages/termui/lib/ui/buffer.dart#L8)**: Represents a single coordinate atom. Contains a single character grapheme cluster and a [Style](/packages/termui/lib/ui/style.dart) (combining RGB [Colors](/packages/termui/lib/ui/color.dart) and bitmask attributes like bold, dim, underline, reverse, and transparency).
+* **[Buffer](/packages/termui/lib/ui/buffer.dart#L49)**: Grid layout representing a rectangular viewport.
+* **[Compositor](/packages/termui/lib/ui/buffer.dart#L149)**: Composites multiple LayeredBuffer components onto a single target screen buffer. It employs a bit-packed `Uint32List` occlusion map to perform an early-exit optimization (skipping drawing cells that are obscured by solid higher Z-index layers).
+* **[Renderer](/packages/termui/lib/ui/renderer.dart)**: Diffs `backBuffer` against `frontBuffer` and outputs minimal ANSI escape updates. Supports both absolute full screen alternate screen addresses and relative offset inline animations.
 
-### B. Input Processing Layer (`lib/ui/event.dart` & `lib/ui/input_parser.dart`)
-Transforms streams of terminal bytes into typed events.
+### C. Element & Widget Tree
+The library replicates a reactive element tree:
+* **[Widget](/packages/termui/lib/ui/layout.dart#L309)**: Immutable configuration classes.
+* **[Element](/packages/termui/lib/ui/layout.dart#L356)**: Mutable nodes managing the lifecycle of the tree.
+* **[StatelessElement](/packages/termui/lib/ui/layout.dart#L477)**: Rebuilds children dynamically on configuration changes.
+* **[StatefulElement](/packages/termui/lib/ui/layout.dart#L607)**: Manages [State](/packages/termui/lib/ui/layout.dart#L564) objects, calling `initState()`, `didUpdateWidget()`, and `dispose()`.
+* **[InheritedElement](/packages/termui/lib/ui/layout.dart#L706)**: Propagates data down the context tree. When updated, it triggers a `rebuild()` to ensure children configurations refresh.
 
-- **[InputParser](file:///app/lib/ui/input_parser.dart)**: Uses a state machine to decode keyboard letters, arrows, function keys (F1–F12) with modifiers (Shift, Alt, Control, Meta), SGR/X10 mouse coordinates, paste blocks (Bracketed Paste Mode), and focus change notifications.
-- **[InputEvent Classes](file:///app/lib/ui/event.dart)**:
-  - `KeyEvent`: Key types and active modifiers.
-  - `MouseEvent`: Positions, click types (press, release, drag, move), and scroll wheels.
-  - `PasteEvent`: Text pasted from clipboard.
-  - `FocusInEvent` / `FocusOutEvent`: State transitions of terminal window focus.
-
-### C. Double Buffering & Compositing (`lib/ui/buffer.dart` & `lib/ui/renderer.dart`)
-Manages screen pixels in-memory to execute fast diff-based frame repaints.
-
-- **[Cell](file:///app/lib/ui/buffer.dart#L8)**: Represents a single coordinates atom. Contains a single character grapheme cluster and a [Style](file:///app/lib/ui/style.dart) (combining RGB [Colors](file:///app/lib/ui/color.dart) and bitmask attributes like bold, dim, underline, reverse, and transparency).
-- **[Buffer](file:///app/lib/ui/buffer.dart#L49)**: Grid layout representing a rectangular viewport.
-- **[Compositor](file:///app/lib/ui/buffer.dart#L149)**: Composites multiple `LayeredBuffer` components onto a single target screen buffer. It employs a bit-packed `Uint32List` occlusion map to perform an early-exit optimization (skipping drawing cells that are obscured by solid higher Z-index layers).
-- **[Renderer](file:///app/lib/ui/renderer.dart)**: Diffs `backBuffer` against `frontBuffer` and outputs minimal ANSI escape updates.
-  - Supports `RenderingMode.alternateScreen` (absolute full screen addresses).
-  - Supports `RenderingMode.inline` (relative offset moves, enabling inline CLI animations/controls without screen clearing).
-
-### D. Layout & Widget Engine (`lib/ui/layout.dart` & `lib/ui/widgets/`)
-Builds structured layout frames and exposes standard widgets. The widgets are organized modularly under `lib/ui/widgets/` and re-exported via [widget_toolkit.dart](file:///app/lib/ui/widget_toolkit.dart).
-
-- **[splitRect](file:///app/lib/ui/layout.dart#L162)**: Splits bounding boxes into coordinates based on constraints (`LengthConstraint`, `PercentageConstraint`, `FlexConstraint`, and `MinMaxConstraint`).
-- **[Viewport](file:///app/lib/ui/layout.dart#L82)**: Implements `Buffer` wrapping to clip and translate relative local coordinate spaces for nested widgets.
-- **Layout Containers**: `Column`, `Row`, and `Stack` layout managers align lists of flex widgets.
-- **Widgets Directory (`lib/ui/widgets/`)**:
-  - `Text` ([text.dart](file:///app/lib/ui/widgets/text.dart)): Renders plain or wrapped text.
-  - `RichText` ([rich_text.dart](file:///app/lib/ui/widgets/rich_text.dart)): Renders styled rich text runs with text wrapping support.
-  - `ListWidget` ([list_widget.dart](file:///app/lib/ui/widgets/list_widget.dart)): Navigable scroll list.
-  - `TextField` ([text_field.dart](file:///app/lib/ui/widgets/text_field.dart)): Single-line or multi-line interactive text entry field with custom cursor, placeholders, and history stacks.
-  - `LinearProgressIndicator` ([linear_progress_indicator.dart](file:///app/lib/ui/widgets/linear_progress_indicator.dart)): Unicode block progress indicator with easing support.
-  - `Canvas` ([canvas.dart](file:///app/lib/ui/widgets/canvas.dart)): 2D Braille grid pixel drawing tool.
-  - `Grid` ([grid.dart](file:///app/lib/ui/widgets/grid.dart)): 2D tile map layer.
-  - `NumberSelector` ([number_selector.dart](file:///app/lib/ui/widgets/number_selector.dart)): Spinner control.
-  - `Padding` ([padding.dart](file:///app/lib/ui/widgets/padding.dart)): Wraps a child widget, shrinking viewport bounds by specified top/bottom/left/right padding offsets.
-  - `Help` ([help.dart](file:///app/lib/ui/widgets/help.dart)): Flexible keybindings help line builder.
-  - `Spinner` ([spinner.dart](file:///app/lib/ui/widgets/spinner.dart)): Animated progress loading indicator.
-  - `Table` ([table.dart](file:///app/lib/ui/widgets/table.dart)): Multi-column grid viewer with header division and selected row cursor tracking.
-  - `Paginator` ([paginator.dart](file:///app/lib/ui/widgets/paginator.dart)): Navigation dot indicator.
-
-### E. Focus & Window Management (`lib/ui/window.dart`)
-Coordinates windows, window hierarchies, drag/resize events, and focus targets.
-
-- **[FocusNode](file:///app/lib/ui/window.dart#L7)**: Represents a leaf or branch in the active keyboard focus tree. Handles request queries and root traversal.
-- **[Window](file:///app/lib/ui/window.dart#L61)**: Floating widget layout frame containing borders, title overrides, and drag handles.
-- **[WindowManager](file:///app/lib/ui/window.dart#L152)**: Manages mouse drag-to-move, click-corner-to-resize, Z-indexing (bringing active windows to the front), and routing incoming key/mouse events to target focus nodes or hit positions.
+### D. Focus & Input Processing
+* **[FocusNode](/packages/termui/lib/ui/window.dart#L74)**: Node in the focus tree representing an interactive layout element.
+* **[FocusScopeNode](/packages/termui/lib/ui/window.dart#L201)**: A specialized node grouping siblings for direction-based focus traversal (up/down/left/right/tab).
+* **[FocusManager](/packages/termui/lib/ui/window.dart#L25)**: Singleton registry tracking `primaryFocus` and coordinating focus paths.
+* **[InputParser](/packages/termui/lib/ui/input_parser.dart)**: Parses raw ansi escape byte streams into [InputEvent](/packages/termui/lib/ui/event.dart) classes (keys, mouse, paste events).
 
 ---
 
-## 4. Quick Start: Coding Guidelines
+## 4. Widget Catalog
 
-When modifying or expanding the codebase:
-1. **Prefer Modern Collection Features**: In compliance with Dart collection guidelines, leverage spread operators (`...`), control-flow elements (`if`, `for`), and null-aware collection entries.
-2. **Buffer Access Optimization**: Do not perform direct `stdout` writing outside the [Renderer](file:///app/lib/ui/renderer.dart) class. Perform all layout drawing operations on the widget's local [Viewport](file:///app/lib/ui/layout.dart#L82) buffer.
-3. **Multi-byte Characters Safety**: When computing widths, slicing strings, or measuring layout boundaries, always use `text.characters` from `package:characters` rather than `text.length` or `text.substring` to prevent breaking multi-byte unicode or emoji sequences.
+All custom widgets are located in the [widgets/](/packages/termui/lib/ui/widgets) directory and re-exported via [widget_toolkit.dart](/packages/termui/lib/ui/widget_toolkit.dart):
+* **[Text](/packages/termui/lib/ui/widgets/text.dart)**: Plain or wrapped text.
+* **[RichText](/packages/termui/lib/ui/widgets/rich_text.dart)**: Text styling runs with automatic wrap support.
+* **[TextField](/packages/termui/lib/ui/widgets/text_field.dart#L316)**: Multi-line / single-line interactive input fields with undo/redo support, text editing controllers, and focused style attributes.
+* **[DecoratedBox](/packages/termui/lib/ui/widgets/decorated_box.dart#L191)**: Applies borders and backgrounds around nested subtrees.
+* **[LinearProgressIndicator](/packages/termui/lib/ui/widgets/linear_progress_indicator.dart)**: Block-based progression indicator.
+* **[Canvas](/packages/termui/lib/ui/widgets/canvas.dart)**: Vector drawing viewport utilizing sub-pixel Braille dot mapping.
+* **[Grid](/packages/termui/lib/ui/widgets/grid.dart)**: 2D tile layout map.
+* **[Window](/packages/termui/lib/ui/window.dart#L241)**: Draggable, resizeable floating window panels.
+
+---
+
+## 5. Development Guidelines & Rules
+
+When writing or modifying code in this repository:
+
+1. **Use Modern Dart Collections**: Leverage Dart collection language features such as `if` elements, `for` elements, spread operators (`...`), and null-aware collection entries. See the [Dart Collections Guide](https://dart.dev/language/collections) for syntax references.
+2. **Multi-byte & Emoji Safety**: Never use `String.length` or `String.substring` for coordinates or drawing offsets. Always use `text.characters` from `package:characters` to handle grapheme cluster boundaries.
+3. **Always Check if Mounted**: Focus changes can fire when widgets are being unmounted or cleaned up. Always guard `setState` calls in focus listeners with an `if (mounted)` check:
+   ```dart
+   focusNode.onFocusChange = (hasFocus) {
+     if (hasFocus && mounted) {
+       setState(() {
+         // Update state properties
+       });
+     }
+   };
+   ```
+4. **Propagate InheritedWidget Updates**: Ensure [InheritedElement.update](/packages/termui/lib/ui/layout.dart#L734) always calls `rebuild()` to ensure that children configurations get updated downstream when the parent rebuilds.
+5. **Conventional Commits**: Write structured, clear commit messages conforming to the Conventional Commits 1.0.0 specification (e.g. `feat(core): ...`, `fix(focus): ...`).
+
+---
+
+## 6. Testing & Golden Suites
+
+All test files are located in [packages/termui/test](/packages/termui/test).
+
+### Testing Practices
+* **Stateful Rebuilds**: Unlike running applications which schedule frame updates on the microtask queue, tests run synchronously. You must call `element.rebuild()`, followed by `element.layout(...)` and `element.paint(...)` to force widgets to redraw after focus or state changes.
+* **Focus Singleton Cleanup**: Since `FocusManager` is a singleton, focus state persists across tests. You must call `FocusManager.instance.setPrimaryFocus(null)` in `setUp()` to ensure a clean slate.
+* **Golden Tests**: Uses `fake_async` and mock recorders to output Golden ANSI files under `test/goldens/` and verifies pixel-perfect compliance.
+
+### Commands
+Run the following commands inside `/app/packages/termui`:
+* Run all unit and integration tests:
+  ```bash
+  dart test
+  ```
+* Run specific test suites:
+  ```bash
+  dart test test/multi_pane_settings_test.dart
+  ```
+* Verify static analysis (returns zero warnings):
+  ```bash
+  dart analyze
+  ```
+* Format codebase:
+  ```bash
+  dart format .
+  ```
+
+---
+
+## 7. Example Gallery & Links
+
+Check out the interactive examples in `packages/termui/example/`:
+* **[01_questionnaire_example.dart](/packages/termui/example/01_questionnaire_example.dart)**: A simple terminal form collecting user answers.
+* **[02_progress_bars.dart](/packages/termui/example/02_progress_bars.dart)**: Demonstrates linear and spinner progression indicators.
+* **[03_responsive_dashboard.dart](/packages/termui/example/03_responsive_dashboard.dart)**: Grid-aligned terminal dashboard that reflows on resize.
+* **[04_multi_pane_settings.dart](/packages/termui/example/04_multi_pane_settings.dart)**: Dual-pane settings panel displaying list-to-detail sibling traversal and text inputs.
+* **[braille_canvas.dart](/packages/termui/example/braille_canvas.dart)**: Demonstrates vector graphics mapping on a braille sub-pixel layout.
+* **[widget_book.dart](/packages/termui/example/widget_book.dart)**: Interactive widget component book with custom page routes.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ graph TD
 
 ## Running Examples
 
-To check out the windowing system and widgets, run any of the built-in examples:
+To check out the windowing system and widgets, navigate to the `packages/termui` directory and run any of the built-in examples:
 
 ```bash
+# Navigate to package directory
+cd packages/termui
+
 # 1. Runs the comprehensive interactive widget book
 dart run example/widget_book.dart
 

--- a/packages/termui/README.md
+++ b/packages/termui/README.md
@@ -101,7 +101,10 @@ void main() async {
       ]);
 
       // Render the layout elements onto the offscreen buffer
-      layout.render(buffer, Rect(0, 0, width, height));
+      final rootElement = layout.createElement()..mount(null);
+      rootElement.layout(BoxConstraints.tight(Size(width, height)));
+      rootElement.paint(buffer, Offset.zero);
+      rootElement.unmount();
 
       // Compute diff and write ANSI sequences to stdout
       final sb = StringBuffer();
@@ -152,9 +155,12 @@ void main() async {
 
 ## Running the Examples
 
-This repository includes several prebuilt showcase examples under the `example/` directory:
+Navigate to the `termui` package directory first, then run the showcase examples:
 
 ```bash
+# Navigate to package directory
+cd packages/termui
+
 # A comprehensive interactive layout and widget explorer
 dart run example/widget_book.dart
 

--- a/packages/termui/example/03_responsive_dashboard.dart
+++ b/packages/termui/example/03_responsive_dashboard.dart
@@ -1,0 +1,563 @@
+// ignore_for_file: file_names
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:characters/characters.dart';
+import 'package:termui/terminal/terminal.dart' as term;
+import 'package:termui/ui/ui.dart';
+
+/// A layout widget that checks constraints and renders a fallback message
+/// if the terminal is below the minimum required width or height.
+class SafeLayout extends Widget {
+  final Widget child;
+  final int minWidth;
+  final int minHeight;
+
+  const SafeLayout({
+    required this.child,
+    this.minWidth = 40,
+    this.minHeight = 10,
+  });
+
+  @override
+  void render(Buffer buffer, Rect area) {
+    if (area.width < minWidth || area.height < minHeight) {
+      final fallback = Center(
+        child: Text(
+          'Screen too small!',
+          style: Style(foreground: Colors.red, modifiers: Modifier.bold),
+        ),
+      );
+      fallback.render(buffer, area);
+    } else {
+      child.render(buffer, area);
+    }
+  }
+
+  @override
+  int getIntrinsicHeight(int width) => child.getIntrinsicHeight(width);
+}
+
+/// A component that renders status indicators with custom styles and borders.
+class StatCard extends StatelessWidget {
+  final String title;
+  final String value;
+  final String detailText;
+  final Widget? detailWidget;
+  final Color color;
+
+  const StatCard({
+    super.key,
+    required this.title,
+    required this.value,
+    this.detailText = '',
+    this.detailWidget,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(border: Border.all(Style(foreground: color))),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 1),
+        child: Column([
+          SizedBox(
+            height: 1,
+            child: Text(
+              title,
+              style: Style(foreground: color, modifiers: Modifier.bold),
+            ),
+          ),
+          const SizedBox(height: 1),
+          SizedBox(
+            height: 1,
+            child: Text(value, style: const Style(modifiers: Modifier.bold)),
+          ),
+          const SizedBox(height: 1),
+          SizedBox(
+            height: 1,
+            child:
+                detailWidget ??
+                Text(detailText, style: const Style(modifiers: Modifier.dim)),
+          ),
+        ]),
+      ),
+    );
+  }
+}
+
+/// A widget that displays operating system details, runtime information, and uptime.
+class SystemInfoPanel extends StatelessWidget {
+  final DateTime bootTime;
+
+  const SystemInfoPanel({super.key, required this.bootTime});
+
+  @override
+  Widget build(BuildContext context) {
+    final uptime = DateTime.now().difference(bootTime);
+    final days = uptime.inDays;
+    final hours = uptime.inHours % 24;
+    final minutes = uptime.inMinutes % 60;
+    final seconds = uptime.inSeconds % 60;
+
+    final uptimeStr = [
+      if (days > 0) '${days}d',
+      if (hours > 0 || days > 0) '${hours}h',
+      if (minutes > 0 || hours > 0 || days > 0) '${minutes}m',
+      '${seconds}s',
+    ].join(' ');
+
+    final timeStr = DateTime.now().toIso8601String().substring(11, 19);
+
+    return Column([
+      const SizedBox(
+        height: 1,
+        child: Text(
+          'SYSTEM INFO',
+          style: Style(foreground: Colors.blue, modifiers: Modifier.bold),
+        ),
+      ),
+      const SizedBox(height: 1),
+      SizedBox(
+        height: 1,
+        child: Text('OS:      ${Platform.operatingSystem.toUpperCase()}'),
+      ),
+      SizedBox(height: 1, child: Text('PID:     $pid')),
+      SizedBox(
+        height: 1,
+        child: Text('Dart:    ${Platform.version.split(" ").first}'),
+      ),
+      SizedBox(height: 1, child: Text('Time:    $timeStr')),
+      SizedBox(height: 1, child: Text('Uptime:  $uptimeStr')),
+    ]);
+  }
+}
+
+/// A custom stateful widget that displays wrapped, bounded log messages with rendering cache.
+class LogWindow extends StatefulWidget {
+  final List<String> logMessages;
+
+  const LogWindow({super.key, required this.logMessages});
+
+  @override
+  State<LogWindow> createState() => _LogWindowState();
+}
+
+class _LogWindowState extends State<LogWindow> {
+  int? _lastWidth;
+  int? _lastLogsLength;
+  String? _lastLogElement;
+  List<String> _wrappedLines = [];
+
+  void _ensureWrapped(int width) {
+    final logs = widget.logMessages;
+    final length = logs.length;
+    final lastElement = logs.isEmpty ? null : logs.last;
+
+    if (_lastWidth == width &&
+        _lastLogsLength == length &&
+        _lastLogElement == lastElement) {
+      return; // Cache hit
+    }
+
+    _wrappedLines = [];
+    for (final msg in logs) {
+      _wrappedLines.addAll(wrapText(msg, width));
+    }
+
+    _lastWidth = width;
+    _lastLogsLength = length;
+    _lastLogElement = lastElement;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _LogWindowRender(
+      onRender: _ensureWrapped,
+      getWrappedLines: () => _wrappedLines,
+    );
+  }
+}
+
+class _LogWindowRender extends Widget {
+  final void Function(int width) onRender;
+  final List<String> Function() getWrappedLines;
+
+  const _LogWindowRender({
+    required this.onRender,
+    required this.getWrappedLines,
+  });
+
+  @override
+  void render(Buffer buffer, Rect area) {
+    if (area.width <= 0 || area.height <= 0) return;
+
+    // Verify cache before rendering
+    onRender(area.width);
+
+    final wrappedLines = getWrappedLines();
+    final startIdx = max(0, wrappedLines.length - area.height);
+    final visibleLines = wrappedLines.sublist(startIdx);
+
+    for (var i = 0; i < visibleLines.length; i++) {
+      if (i >= area.height) break;
+      buffer.writeString(0, i, visibleLines[i], Style.empty);
+    }
+  }
+
+  @override
+  int getIntrinsicHeight(int width) => 0;
+}
+
+/// Helper function to wrap text safely using characters visual width measurement.
+List<String> wrapText(String text, int maxWidth) {
+  if (maxWidth <= 0) return [];
+  final lines = <String>[];
+  final paragraphs = text.split('\n');
+
+  for (final paragraph in paragraphs) {
+    if (paragraph.isEmpty) {
+      lines.add('');
+      continue;
+    }
+
+    final words = paragraph.split(' ');
+    var currentLine = '';
+    var currentLineLen = 0;
+
+    for (final word in words) {
+      if (word.isEmpty) continue;
+
+      final wordWidth = measureStringWidth(word);
+
+      if (currentLine.isEmpty) {
+        if (wordWidth <= maxWidth) {
+          currentLine = word;
+          currentLineLen = wordWidth;
+        } else {
+          _splitWordIntoLines(word, maxWidth, lines);
+        }
+      } else {
+        if (currentLineLen + 1 + wordWidth <= maxWidth) {
+          currentLine += ' $word';
+          currentLineLen += 1 + wordWidth;
+        } else {
+          lines.add(currentLine);
+          if (wordWidth <= maxWidth) {
+            currentLine = word;
+            currentLineLen = wordWidth;
+          } else {
+            currentLine = '';
+            currentLineLen = 0;
+            _splitWordIntoLines(word, maxWidth, lines);
+          }
+        }
+      }
+    }
+
+    if (currentLine.isNotEmpty) {
+      lines.add(currentLine);
+    }
+  }
+
+  return lines;
+}
+
+void _splitWordIntoLines(String word, int maxWidth, List<String> lines) {
+  final chunk = StringBuffer();
+  var takeWidth = 0;
+  for (final char in word.characters) {
+    final w = isWideGrapheme(char) ? 2 : 1;
+    if (takeWidth + w > maxWidth) {
+      if (chunk.isNotEmpty) {
+        lines.add(chunk.toString());
+        chunk.clear();
+        takeWidth = 0;
+      }
+    }
+    chunk.write(char);
+    takeWidth += w;
+  }
+  if (chunk.isNotEmpty) {
+    lines.add(chunk.toString());
+  }
+}
+
+/// The main Dashboard Application root widget coordinating simulation timers.
+class DashboardApp extends StatefulWidget {
+  const DashboardApp({super.key});
+
+  @override
+  State<DashboardApp> createState() => _DashboardAppState();
+}
+
+class _DashboardAppState extends State<DashboardApp> {
+  late final DateTime bootTime;
+  double cpuUsage = 0.45;
+  double ramUsed = 8.2;
+  final double ramTotal = 16.0;
+  double txSpeed = 1.2;
+  double rxSpeed = 3.4;
+  final List<String> logMessages = [];
+
+  Timer? _metricsTimer;
+  Timer? _logTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    bootTime = DateTime.now();
+    _startSimulationTimers();
+  }
+
+  @override
+  void dispose() {
+    _metricsTimer?.cancel();
+    _logTimer?.cancel();
+    super.dispose();
+  }
+
+  void _startSimulationTimers() {
+    final random = Random();
+
+    _metricsTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      setState(() {
+        cpuUsage = (cpuUsage + (random.nextDouble() * 0.2 - 0.1)).clamp(
+          0.0,
+          1.0,
+        );
+        ramUsed = (ramUsed + (random.nextDouble() * 0.4 - 0.2)).clamp(
+          2.0,
+          ramTotal - 0.5,
+        );
+        txSpeed = (txSpeed + (random.nextDouble() * 0.8 - 0.4)).clamp(
+          0.1,
+          100.0,
+        );
+        rxSpeed = (rxSpeed + (random.nextDouble() * 1.5 - 0.75)).clamp(
+          0.1,
+          250.0,
+        );
+      });
+    });
+
+    _logTimer = Timer.periodic(const Duration(milliseconds: 500), (timer) {
+      final templates = [
+        'GET /api/v1/status - 200 OK',
+        'POST /api/v1/auth/login - 401 Unauthorized',
+        'GET /api/v1/users - 200 OK',
+        'Database connection pool health check: OK',
+        'Scheduled cron: clean_sessions executed in 12ms',
+        'Worker thread #${random.nextInt(8)} spawned successfully',
+        'Warning: High disk I/O detected on /dev/sda1',
+        'Backup job: finished uploading snapshot_backup.tar.gz',
+        'Cache invalidated for user_${random.nextInt(1000)}',
+        'System updated: packages security patches applied',
+        'Connected to redis instance at 127.0.0.1:6379',
+      ];
+      final timestamp = DateTime.now().toIso8601String().substring(11, 19);
+      final newLog =
+          '[$timestamp] ${templates[random.nextInt(templates.length)]}';
+
+      setState(() {
+        logMessages.add(newLog);
+        if (logMessages.length > 100) {
+          logMessages.removeAt(0);
+        }
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cpuCard = StatCard(
+      title: ' CPU USAGE ',
+      value: '${(cpuUsage * 100).toStringAsFixed(1)}%',
+      detailWidget: LinearProgressIndicator(
+        cpuUsage.clamp(0.0, 1.0),
+        smooth: true,
+        style: const Style(foreground: Colors.green),
+      ),
+      color: Colors.green,
+    );
+
+    final memCard = StatCard(
+      title: ' MEMORY (RAM) ',
+      value:
+          '${ramUsed.toStringAsFixed(1)} GB / ${ramTotal.toStringAsFixed(1)} GB',
+      detailWidget: LinearProgressIndicator(
+        (ramUsed / ramTotal).clamp(0.0, 1.0),
+        smooth: true,
+        style: const Style(foreground: Colors.blue),
+      ),
+      color: Colors.blue,
+    );
+
+    final netCard = StatCard(
+      title: ' NETWORK TRAFFIC ',
+      value: 'TX: ${txSpeed.toStringAsFixed(1)} MB/s',
+      detailText: 'RX: ${rxSpeed.toStringAsFixed(1)} MB/s',
+      color: Colors.yellow,
+    );
+
+    final logPanel = DecoratedBox(
+      decoration: const BoxDecoration(
+        border: Border.all(Style(foreground: Colors.white)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 1),
+        child: Column([
+          const SizedBox(
+            height: 1,
+            child: Text(
+              ' SERVER LOGS ',
+              style: Style(modifiers: Modifier.bold),
+            ),
+          ),
+          const SizedBox(height: 1),
+          Expanded(child: LogWindow(logMessages: logMessages)),
+        ]),
+      ),
+    );
+
+    final sysPanel = DecoratedBox(
+      decoration: const BoxDecoration(
+        border: Border.all(Style(foreground: Colors.blue)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 1),
+        child: SystemInfoPanel(bootTime: bootTime),
+      ),
+    );
+
+    final dashboardContent = Column([
+      SizedBox(
+        height: 1,
+        child: DecoratedBox(
+          decoration: const BoxDecoration(
+            backgroundStyle: Style(background: Colors.blue),
+          ),
+          child: Center(
+            child: Text(
+              ' 💻 SERVER MONITORING DASHBOARD 💻 ',
+              style: Style(
+                foreground: Colors.white,
+                background: Colors.blue,
+                modifiers: Modifier.bold,
+              ),
+            ),
+          ),
+        ),
+      ),
+      const SizedBox(height: 1),
+      Expanded(
+        flex: 1,
+        child: Row([
+          Expanded(child: cpuCard),
+          const SizedBox(width: 1),
+          Expanded(child: memCard),
+          const SizedBox(width: 1),
+          Expanded(child: netCard),
+        ]),
+      ),
+      const SizedBox(height: 1),
+      Expanded(
+        flex: 2,
+        child: Row([
+          Expanded(flex: 2, child: logPanel),
+          const SizedBox(width: 1),
+          Expanded(flex: 1, child: sysPanel),
+        ]),
+      ),
+      const SizedBox(height: 1),
+      const SizedBox(
+        height: 1,
+        child: Center(
+          child: Text(
+            'Press [Q] or Ctrl+C to Quit',
+            style: Style(modifiers: Modifier.dim),
+          ),
+        ),
+      ),
+    ]);
+
+    return SafeLayout(minWidth: 40, minHeight: 10, child: dashboardContent);
+  }
+}
+
+void main() async {
+  await term.Terminal.runGuarded((terminal) async {
+    final termSize = await terminal.size;
+    var width = termSize.x;
+    var height = termSize.y;
+
+    terminal.enterAlternateScreen();
+    terminal.hideCursor();
+
+    final buffer = Buffer.blank(width, height);
+    var renderer = Renderer(width, height, mode: RenderingMode.alternateScreen);
+
+    final elementWrapper = ElementWidget(const DashboardApp());
+
+    void drawFrame() {
+      buffer.clear();
+      buffer.fill(Cell(' ', Style.empty));
+      elementWrapper.render(buffer, Rect(0, 0, width, height));
+
+      final sb = StringBuffer();
+      renderer.render(buffer, sb);
+      if (sb.isNotEmpty) {
+        stdout.write(sb.toString());
+      }
+    }
+
+    // Coalesce updates in a microtask to prevent pipeline thrashing
+    bool frameScheduled = false;
+    void scheduleRepaint() {
+      if (!frameScheduled) {
+        frameScheduled = true;
+        scheduleMicrotask(() {
+          drawFrame();
+          frameScheduled = false;
+        });
+      }
+    }
+
+    State.onNeedRepaint = scheduleRepaint;
+    drawFrame();
+
+    final sizeSubscription = terminal.watchSize().listen((size) {
+      width = size.x;
+      height = size.y;
+      buffer.resize(width, height);
+      renderer = Renderer(width, height, mode: RenderingMode.alternateScreen);
+      // Size changes are passed declaratively down the tree during render
+      drawFrame();
+    });
+
+    try {
+      await for (final event in terminal.events) {
+        if (event is term.KeyEvent) {
+          if (event.key == 'q' || event.key == 'Q') {
+            break;
+          }
+          if (event.key.length == 1 && event.key.codeUnits[0] == 3) {
+            break; // Ctrl+C
+          }
+        }
+      }
+    } finally {
+      sizeSubscription.cancel();
+      elementWrapper.element?.unmount();
+      State.onNeedRepaint = null;
+      terminal.showCursor();
+      terminal.exitAlternateScreen();
+      terminal.resetStyle();
+    }
+  });
+  print('Dashboard demo exited cleanly.');
+  exit(0);
+}

--- a/packages/termui/example/03_responsive_dashboard.dart
+++ b/packages/termui/example/03_responsive_dashboard.dart
@@ -22,22 +22,99 @@ class SafeLayout extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width < minWidth || area.height < minHeight) {
-      final fallback = Center(
-        child: Text(
-          'Screen too small!',
-          style: Style(foreground: Colors.red, modifiers: Modifier.bold),
-        ),
-      );
-      fallback.render(buffer, area);
+  Element createElement() => SafeLayoutElement(this);
+
+  @override
+  int getIntrinsicHeight(int width) => child.getIntrinsicHeight(width);
+}
+
+class SafeLayoutElement extends Element {
+  Element? fallbackElement;
+  Element? childElement;
+  bool useFallback = false;
+
+  SafeLayoutElement(SafeLayout super.widget);
+
+  @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    final sl = widget as SafeLayout;
+    final fallback = Center(
+      child: Text(
+        'Screen too small!',
+        style: Style(foreground: Colors.red, modifiers: Modifier.bold),
+      ),
+    );
+
+    if (fallbackElement != null) {
+      fallbackElement!.update(fallback);
     } else {
-      child.render(buffer, area);
+      fallbackElement = fallback.createElement();
+      fallbackElement!.mount(this);
+    }
+
+    if (childElement != null &&
+        childElement!.widget.runtimeType == sl.child.runtimeType) {
+      childElement!.update(sl.child);
+    } else {
+      childElement?.unmount();
+      childElement = sl.child.createElement();
+      childElement!.mount(this);
     }
   }
 
   @override
-  int getIntrinsicHeight(int width) => child.getIntrinsicHeight(width);
+  void visitChildren(void Function(Element child) visitor) {
+    if (useFallback) {
+      if (fallbackElement != null) visitor(fallbackElement!);
+    } else {
+      if (childElement != null) visitor(childElement!);
+    }
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final sl = widget as SafeLayout;
+    final w = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    final h = constraints.maxHeight == BoxConstraints.infinity
+        ? 0
+        : constraints.maxHeight;
+
+    if (w < sl.minWidth || h < sl.minHeight) {
+      useFallback = true;
+      if (fallbackElement != null) {
+        fallbackElement!.layout(constraints);
+      }
+    } else {
+      useFallback = false;
+      if (childElement != null) {
+        childElement!.layout(constraints);
+      }
+    }
+    return constraints.constrain(Size(w, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    if (useFallback) {
+      fallbackElement?.paint(buffer, offset);
+    } else {
+      childElement?.paint(buffer, offset);
+    }
+  }
 }
 
 /// A component that renders status indicators with custom styles and borders.
@@ -192,24 +269,47 @@ class _LogWindowRender extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
+  Element createElement() => _LogWindowRenderElement(this);
+}
 
-    // Verify cache before rendering
-    onRender(area.width);
+class _LogWindowRenderElement extends Element {
+  _LogWindowRenderElement(_LogWindowRender super.widget);
 
-    final wrappedLines = getWrappedLines();
-    final startIdx = max(0, wrappedLines.length - area.height);
-    final visibleLines = wrappedLines.sublist(startIdx);
-
-    for (var i = 0; i < visibleLines.length; i++) {
-      if (i >= area.height) break;
-      buffer.writeString(0, i, visibleLines[i], Style.empty);
-    }
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final w = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    final h = constraints.maxHeight == BoxConstraints.infinity
+        ? 0
+        : constraints.maxHeight;
+    return constraints.constrain(Size(w, h));
   }
 
   @override
-  int getIntrinsicHeight(int width) => 0;
+  void paint(Buffer buffer, Offset offset) {
+    final w = widget as _LogWindowRender;
+    final areaWidth = size.width.toInt();
+    final areaHeight = size.height.toInt();
+    if (areaWidth <= 0 || areaHeight <= 0) return;
+
+    // Verify cache before rendering
+    w.onRender(areaWidth);
+
+    final wrappedLines = w.getWrappedLines();
+    final startIdx = max(0, wrappedLines.length - areaHeight);
+    final visibleLines = wrappedLines.sublist(startIdx);
+
+    for (var i = 0; i < visibleLines.length; i++) {
+      if (i >= areaHeight) break;
+      buffer.writeString(
+        offset.dx.toInt(),
+        offset.dy.toInt() + i,
+        visibleLines[i],
+        Style.empty,
+      );
+    }
+  }
 }
 
 /// Helper function to wrap text safely using characters visual width measurement.
@@ -505,7 +605,8 @@ void main() async {
     void drawFrame() {
       buffer.clear();
       buffer.fill(Cell(' ', Style.empty));
-      elementWrapper.render(buffer, Rect(0, 0, width, height));
+      elementWrapper.layout(BoxConstraints.tight(Size(width, height)));
+      elementWrapper.paint(buffer, Offset.zero);
 
       final sb = StringBuffer();
       renderer.render(buffer, sb);

--- a/packages/termui/example/braille_canvas.dart
+++ b/packages/termui/example/braille_canvas.dart
@@ -20,6 +20,7 @@ void main() async {
     height - 2,
     style: const Style(foreground: Colors.green),
   );
+  final canvasElement = canvas.createElement()..mount(null);
 
   print('\x1b[?25l'); // Hide cursor
   print('\x1b[2J'); // Clear screen
@@ -58,9 +59,11 @@ void main() async {
       const Style(foreground: Colors.white, modifiers: Modifier.bold),
     );
 
-    // Render canvas inside the layout area
     final canvasArea = const Rect(0, 1, width, height - 2);
-    canvas.render(buffer, canvasArea);
+    canvasElement.layout(
+      BoxConstraints.tight(Size(canvasArea.width, canvasArea.height)),
+    );
+    canvasElement.paint(buffer, Offset(canvasArea.x, canvasArea.y));
 
     buffer.writeString(
       0,

--- a/packages/termui/example/dashboard_demo.dart
+++ b/packages/termui/example/dashboard_demo.dart
@@ -441,8 +441,8 @@ void main() async {
     void drawFrame() {
       buffer.clear();
       // Pre-fill background
-      buffer.fill(Cell(' ', Style.empty));
-      elementWrapper.render(buffer, Rect(0, 0, width, height));
+      elementWrapper.layout(BoxConstraints.tight(Size(width, height)));
+      elementWrapper.paint(buffer, Offset.zero);
 
       final sb = StringBuffer();
       renderer.render(buffer, sb);

--- a/packages/termui/example/layout_demo.dart
+++ b/packages/termui/example/layout_demo.dart
@@ -75,7 +75,9 @@ void main() {
     ),
   ]);
 
-  layout.render(buffer, const Rect(0, 0, width, height));
+  final elementWrapper = ElementWidget(layout);
+  elementWrapper.layout(BoxConstraints.tight(Size(width, height)));
+  elementWrapper.paint(buffer, Offset.zero);
 
   final buf = StringBuffer();
   // Render buffer to stdout

--- a/packages/termui/example/scenario_a_demo.dart
+++ b/packages/termui/example/scenario_a_demo.dart
@@ -62,7 +62,9 @@ void main() async {
         ),
       ]);
 
-      layout.render(buffer, Rect(0, 0, width, height));
+      final elementWrapper = ElementWidget(layout);
+      elementWrapper.layout(BoxConstraints.tight(Size(width, height)));
+      elementWrapper.paint(buffer, Offset.zero);
 
       final sb = StringBuffer();
       renderer.render(buffer, sb);

--- a/packages/termui/example/scroll_input_demo.dart
+++ b/packages/termui/example/scroll_input_demo.dart
@@ -330,7 +330,9 @@ void main() async {
         ]),
       );
 
-      rootWidget.render(buffer, Rect(0, 0, width, height));
+      final rootWrapper = ElementWidget(rootWidget);
+      rootWrapper.layout(BoxConstraints.tight(Size(width, height)));
+      rootWrapper.paint(buffer, Offset.zero);
 
       if (submitted) {
         final okBtnNode = FocusNode(id: 'okBtn');
@@ -430,7 +432,9 @@ void main() async {
             ),
           ),
         );
-        modal.render(buffer, Rect(0, 0, width, height));
+        final modalWrapper = ElementWidget(modal);
+        modalWrapper.layout(BoxConstraints.tight(Size(width, height)));
+        modalWrapper.paint(buffer, Offset.zero);
       }
 
       final sb = StringBuffer();

--- a/packages/termui/example/state.dart
+++ b/packages/termui/example/state.dart
@@ -7,35 +7,52 @@ import 'package:termui/ui/layout.dart';
 import 'package:termui/ui/renderer.dart';
 import 'package:termui/ui/widget_toolkit.dart';
 
-// A custom styled Container widget since termui doesn't have DecoratedBox/Container yet
-class Container extends Widget {
+// A custom styled Container widget using composition
+class Container extends StatelessWidget {
   final Widget child;
   final Style style;
 
   const Container({required this.child, required this.style});
 
   @override
-  void render(Buffer buffer, Rect area) {
-    // Fill the area with the background and foreground style
-    for (var y = 0; y < area.height; y++) {
-      for (var x = 0; x < area.width; x++) {
-        buffer.setCell(x, y, Cell(' ', style));
-      }
-    }
-    // Render child widget within this area
-    child.render(buffer, area);
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(backgroundStyle: style),
+      child: child,
+    );
   }
 }
 
-// A custom VerticalDivider widget to draw a solid vertical separator line
+// A custom VerticalDivider widget using custom element paint
 class VerticalDivider extends Widget {
   final Style style;
   const VerticalDivider({required this.style});
 
   @override
-  void render(Buffer buffer, Rect area) {
-    for (var y = 0; y < area.height; y++) {
-      buffer.setCell(0, y, Cell('│', style));
+  Element createElement() => _VerticalDividerElement(this);
+}
+
+class _VerticalDividerElement extends Element {
+  _VerticalDividerElement(VerticalDivider super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final w = constraints.minWidth;
+    final h = constraints.maxHeight == BoxConstraints.infinity
+        ? 0
+        : constraints.maxHeight;
+    return constraints.constrain(Size(w > 1 ? w : 1, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final v = widget as VerticalDivider;
+    for (var y = 0; y < size.height; y++) {
+      buffer.setCell(
+        offset.dx.toInt(),
+        (offset.dy + y).toInt(),
+        Cell('│', v.style),
+      );
     }
   }
 }
@@ -351,7 +368,8 @@ void main() async {
     buffer.fill(Cell(' ', Style.empty));
 
     // Render the mounted element tree to the buffer
-    elementWrapper.render(buffer, Rect(0, 0, width, height));
+    elementWrapper.layout(BoxConstraints.tight(Size(width, height)));
+    elementWrapper.paint(buffer, Offset.zero);
 
     // Output to stdout via Renderer diffing
     final sb = StringBuffer();

--- a/packages/termui/example/theme_decoration_demo.dart
+++ b/packages/termui/example/theme_decoration_demo.dart
@@ -398,7 +398,9 @@ void main() async {
         data: isDarkTheme ? ThemeData.dark : ThemeData.light,
         child: const ThemeDemoDashboard(),
       );
-      rootWidget.render(buffer, Rect(0, 0, width, height));
+      final rootWrapper = ElementWidget(rootWidget);
+      rootWrapper.layout(BoxConstraints.tight(Size(width, height)));
+      rootWrapper.paint(buffer, Offset.zero);
 
       final sb = StringBuffer();
       renderer.render(buffer, sb);

--- a/packages/termui/example/window_manager_interactive.dart
+++ b/packages/termui/example/window_manager_interactive.dart
@@ -195,7 +195,9 @@ void main() async {
       ..sort((a, b) => a.zIndex.compareTo(b.zIndex));
 
     for (final win in sortedWins) {
-      win.render(screenBuffer, Rect(0, 0, width, height));
+      final winElement = win.createElement()..mount(null);
+      winElement.layout(BoxConstraints.tight(Size(width, height)));
+      winElement.paint(screenBuffer, Offset.zero);
     }
 
     // Top status bar

--- a/packages/termui/lib/ui/layout.dart
+++ b/packages/termui/lib/ui/layout.dart
@@ -4,6 +4,172 @@ import 'package:characters/characters.dart';
 import 'buffer.dart';
 import 'style.dart';
 
+/// Represents integer dimensions on the terminal cell grid.
+class Size {
+  /// The horizontal dimension.
+  final int width;
+
+  /// The vertical dimension.
+  final int height;
+
+  /// Creates a [Size] with the given [width] and [height].
+  const Size(this.width, this.height);
+
+  /// A size with zero width and height.
+  static const Size zero = Size(0, 0);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Size && other.width == width && other.height == height;
+
+  @override
+  int get hashCode => Object.hash(width, height);
+
+  @override
+  String toString() => 'Size($width, $height)';
+}
+
+/// Represents an offset on the terminal cell grid coordinate space.
+class Offset {
+  /// The horizontal offset.
+  final int dx;
+
+  /// The vertical offset.
+  final int dy;
+
+  /// Creates an [Offset] with the given [dx] and [dy].
+  const Offset(this.dx, this.dy);
+
+  /// An offset with zero horizontal and vertical values.
+  static const Offset zero = Offset(0, 0);
+
+  /// Adds [other] offset to this offset.
+  Offset operator +(Offset other) => Offset(dx + other.dx, dy + other.dy);
+
+  /// Subtracts [other] offset from this offset.
+  Offset operator -(Offset other) => Offset(dx - other.dx, dy - other.dy);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Offset && other.dx == dx && other.dy == dy;
+
+  @override
+  int get hashCode => Object.hash(dx, dy);
+
+  @override
+  String toString() => 'Offset($dx, $dy)';
+}
+
+/// Defines layout boundaries inside terminal cell limits.
+class BoxConstraints {
+  /// The minimum width allowed.
+  final int minWidth;
+
+  /// The maximum width allowed.
+  final int maxWidth;
+
+  /// The minimum height allowed.
+  final int minHeight;
+
+  /// The maximum height allowed.
+  final int maxHeight;
+
+  /// The default maximum value indicating unbounded constraints.
+  static const int infinity = 999999;
+
+  /// Creates box constraints with the given limits.
+  const BoxConstraints({
+    this.minWidth = 0,
+    this.maxWidth = infinity,
+    this.minHeight = 0,
+    this.maxHeight = infinity,
+  });
+
+  /// Creates box constraints that require the given size exactly.
+  BoxConstraints.tight(Size size)
+    : minWidth = size.width,
+      maxWidth = size.width,
+      minHeight = size.height,
+      maxHeight = size.height;
+
+  /// Creates box constraints that forbid sizes larger than the given size.
+  BoxConstraints.loose(Size size)
+    : minWidth = 0,
+      maxWidth = size.width,
+      minHeight = 0,
+      maxHeight = size.height;
+
+  /// Creates box constraints that require the given width or height.
+  const BoxConstraints.tightFor({int? width, int? height})
+    : minWidth = width ?? 0,
+      maxWidth = width ?? infinity,
+      minHeight = height ?? 0,
+      maxHeight = height ?? infinity;
+
+  /// Clamps the input [Size] within these constraints.
+  Size constrain(Size size) {
+    return Size(
+      size.width.clamp(minWidth, maxWidth),
+      size.height.clamp(minHeight, maxHeight),
+    );
+  }
+
+  /// Whether the maximum width is bounded.
+  bool get hasBoundedWidth => maxWidth < infinity;
+
+  /// Whether the maximum height is bounded.
+  bool get hasBoundedHeight => maxHeight < infinity;
+
+  /// Whether the constraints are tight (min and max match for both width and height).
+  bool get isTight => minWidth == maxWidth && minHeight == maxHeight;
+
+  /// Creates a copy of this [BoxConstraints] with updated values.
+  BoxConstraints copyWith({
+    int? minWidth,
+    int? maxWidth,
+    int? minHeight,
+    int? maxHeight,
+  }) {
+    return BoxConstraints(
+      minWidth: minWidth ?? this.minWidth,
+      maxWidth: maxWidth ?? this.maxWidth,
+      minHeight: minHeight ?? this.minHeight,
+      maxHeight: maxHeight ?? this.maxHeight,
+    );
+  }
+
+  /// Enforces the given [constraints] on this constraint.
+  BoxConstraints enforce(BoxConstraints constraints) {
+    return BoxConstraints(
+      minWidth: minWidth.clamp(constraints.minWidth, constraints.maxWidth),
+      maxWidth: maxWidth.clamp(constraints.minWidth, constraints.maxWidth),
+      minHeight: minHeight.clamp(constraints.minHeight, constraints.maxHeight),
+      maxHeight: maxHeight.clamp(constraints.minHeight, constraints.maxHeight),
+    );
+  }
+
+  /// Tightens the constraints with the given width and height.
+  BoxConstraints tighten({int? width, int? height}) {
+    return BoxConstraints(
+      minWidth: width == null ? minWidth : width.clamp(minWidth, maxWidth),
+      maxWidth: width == null ? maxWidth : width.clamp(minWidth, maxWidth),
+      minHeight: height == null
+          ? minHeight
+          : height.clamp(minHeight, maxHeight),
+      maxHeight: height == null
+          ? maxHeight
+          : height.clamp(minHeight, maxHeight),
+    );
+  }
+
+  @override
+  String toString() {
+    return 'BoxConstraints(minWidth: $minWidth, maxWidth: $maxWidth, minHeight: $minHeight, maxHeight: $maxHeight)';
+  }
+}
+
 /// A 2D rectangle representing bounds in terminal space.
 class Rect {
   /// The horizontal x-coordinate of the rectangle's top-left corner.
@@ -180,9 +346,6 @@ abstract class Widget {
   /// Creates an [Element] to manage this widget's location in the tree.
   Element createElement() => LeafElement(this);
 
-  /// Renders the widget onto the provided [buffer] within the specified [area].
-  void render(Buffer buffer, Rect area);
-
   /// Computes the intrinsic height of this widget under the given [width] constraint.
   int getIntrinsicHeight(int width) {
     return 1;
@@ -197,6 +360,15 @@ abstract class Element implements BuildContext {
 
   /// The parent element in the widget tree.
   Element? parent;
+
+  BoxConstraints? _cachedConstraints;
+  Size? _cachedSize;
+
+  /// The cached constraints from the last layout pass.
+  BoxConstraints? get constraints => _cachedConstraints;
+
+  /// The resolved size of the element from the last layout pass.
+  Size get size => _cachedSize ?? Size.zero;
 
   /// Creates an element that uses the given [widget] as its configuration.
   Element(this.widget);
@@ -224,8 +396,25 @@ abstract class Element implements BuildContext {
     widget = newWidget;
   }
 
-  /// Renders the underlying widget to the provided [buffer] within the [area].
-  void render(Buffer buffer, Rect area);
+  /// Calculates the size of the element based on the given constraints.
+  Size layout(BoxConstraints constraints) {
+    _cachedConstraints = constraints;
+    final resolvedSize = performLayout(constraints);
+    _cachedSize = constraints.constrain(resolvedSize);
+    return _cachedSize!;
+  }
+
+  /// Hook for subclasses to perform layout within the given constraints.
+  Size performLayout(BoxConstraints constraints) {
+    final width = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    final height = widget.getIntrinsicHeight(width);
+    return constraints.constrain(Size(width, height));
+  }
+
+  /// Paints the element onto the provided buffer at the given offset.
+  void paint(Buffer buffer, Offset offset) {}
 
   /// Invokes [visitor] on each child element of this node.
   void visitChildren(void Function(Element child) visitor) {}
@@ -252,11 +441,16 @@ class LeafElement extends Element {
   LeafElement(super.widget);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    runZoned(() {
-      widget.render(buffer, area);
-    }, zoneValues: {#buildContext: this});
+  Size performLayout(BoxConstraints constraints) {
+    final width = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    final height = widget.getIntrinsicHeight(width);
+    return constraints.constrain(Size(width, height));
   }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {}
 }
 
 /// A widget that has configuration but delegates rendering to its built child.
@@ -269,13 +463,6 @@ abstract class StatelessWidget extends Widget {
 
   @override
   Element createElement() => StatelessElement(this);
-
-  @override
-  void render(Buffer buffer, Rect area) {
-    // Statelessly build and render child directly if called outside of an active element tree.
-    final rootContext = StatelessElement(this)..mount(null);
-    rootContext.render(buffer, area);
-  }
 
   @override
   int getIntrinsicHeight(int width) {
@@ -337,10 +524,16 @@ class StatelessElement extends Element {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    runZoned(() {
-      childElement?.render(buffer, area);
-    }, zoneValues: {#buildContext: this});
+  Size performLayout(BoxConstraints constraints) {
+    if (childElement != null) {
+      return childElement!.layout(constraints);
+    }
+    return constraints.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    childElement?.paint(buffer, offset);
   }
 }
 
@@ -354,13 +547,6 @@ abstract class StatefulWidget extends Widget {
 
   @override
   Element createElement() => StatefulElement(this);
-
-  @override
-  void render(Buffer buffer, Rect area) {
-    // Lazily run stateful loop if rendered without app container.
-    final rootContext = StatefulElement(this)..mount(null);
-    rootContext.render(buffer, area);
-  }
 
   @override
   int getIntrinsicHeight(int width) {
@@ -483,10 +669,16 @@ class StatefulElement extends Element {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    runZoned(() {
-      childElement?.render(buffer, area);
-    }, zoneValues: {#buildContext: this});
+  Size performLayout(BoxConstraints constraints) {
+    if (childElement != null) {
+      return childElement!.layout(constraints);
+    }
+    return constraints.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    childElement?.paint(buffer, offset);
   }
 }
 
@@ -500,12 +692,6 @@ abstract class InheritedWidget extends Widget {
 
   @override
   Element createElement() => InheritedElement(this);
-
-  @override
-  void render(Buffer buffer, Rect area) {
-    final rootContext = InheritedElement(this)..mount(null);
-    rootContext.render(buffer, area);
-  }
 
   @override
   int getIntrinsicHeight(int width) {
@@ -546,12 +732,8 @@ class InheritedElement extends Element {
 
   @override
   void update(Widget newWidget) {
-    final oldWidget = widget as InheritedWidget;
     super.update(newWidget);
-    final nextWidget = newWidget as InheritedWidget;
-    if (nextWidget.updateShouldNotify(oldWidget)) {
-      rebuild();
-    }
+    rebuild();
   }
 
   @override
@@ -560,10 +742,16 @@ class InheritedElement extends Element {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    runZoned(() {
-      childElement?.render(buffer, area);
-    }, zoneValues: {#buildContext: this});
+  Size performLayout(BoxConstraints constraints) {
+    if (childElement != null) {
+      return childElement!.layout(constraints);
+    }
+    return constraints.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    childElement?.paint(buffer, offset);
   }
 }
 
@@ -879,16 +1067,6 @@ Constraint _getConstraint(Widget widget, LayoutDirection direction) {
   return const FlexConstraint(1);
 }
 
-Widget _getRealWidget(Widget widget) {
-  if (widget is Flexible) {
-    return widget.child;
-  }
-  if (widget is SizedBox) {
-    return widget.child ?? const SizedBox.shrink();
-  }
-  return widget;
-}
-
 /// A layout widget that arranges its children horizontally.
 class Row extends Widget {
   /// The children widgets to align horizontally.
@@ -899,21 +1077,6 @@ class Row extends Widget {
 
   @override
   Element createElement() => RowElement(this);
-
-  @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
-    final constraints = children
-        .map((c) => _getConstraint(c, LayoutDirection.horizontal))
-        .toList();
-    final rects = splitRect(area, constraints, LayoutDirection.horizontal);
-    for (var i = 0; i < children.length; i++) {
-      final child = _getRealWidget(children[i]);
-      final childArea = rects[i];
-      final viewport = Viewport(buffer, childArea);
-      child.render(viewport, Rect(0, 0, childArea.width, childArea.height));
-    }
-  }
 
   @override
   int getIntrinsicHeight(int width) {
@@ -939,28 +1102,26 @@ class Row extends Widget {
 class RowElement extends Element {
   /// The list of managed child elements.
   List<Element> childElements = [];
+  List<Offset> _childOffsets = [];
 
   /// Creates a row element for a [Row] widget.
   RowElement(Row super.widget);
 
   @override
-  void unmount() {
-    for (final child in childElements) {
-      child.unmount();
-    }
-    super.unmount();
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
     final row = widget as Row;
-    if (area.width <= 0 || area.height <= 0) return;
-
-    final constraints = row.children
-        .map((c) => _getConstraint(c, LayoutDirection.horizontal))
-        .toList();
-    final rects = splitRect(area, constraints, LayoutDirection.horizontal);
-
     final newElements = <Element>[];
     for (var i = 0; i < row.children.length; i++) {
       final childWidget = row.children[i];
@@ -981,12 +1142,61 @@ class RowElement extends Element {
       childElements[i].unmount();
     }
     childElements = newElements;
+  }
+
+  @override
+  void unmount() {
+    for (final child in childElements) {
+      child.unmount();
+    }
+    super.unmount();
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final row = widget as Row;
+    final width = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    final height = constraints.maxHeight == BoxConstraints.infinity
+        ? 0
+        : constraints.maxHeight;
+    final area = Rect(0, 0, width, height);
+
+    final rowConstraints = row.children
+        .map((c) => _getConstraint(c, LayoutDirection.horizontal))
+        .toList();
+    final rects = splitRect(area, rowConstraints, LayoutDirection.horizontal);
+
+    _childOffsets = List<Offset>.filled(childElements.length, Offset.zero);
+    var maxChildHeight = 0;
 
     for (var i = 0; i < childElements.length; i++) {
       final childEl = childElements[i];
       final childArea = rects[i];
-      final viewport = Viewport(buffer, childArea);
-      childEl.render(viewport, Rect(0, 0, childArea.width, childArea.height));
+      _childOffsets[i] = Offset(childArea.x, childArea.y);
+      final childSize = childEl.layout(
+        BoxConstraints(
+          minWidth: childArea.width,
+          maxWidth: childArea.width,
+          minHeight: 0,
+          maxHeight: height,
+        ),
+      );
+      if (childSize.height > maxChildHeight) {
+        maxChildHeight = childSize.height;
+      }
+    }
+    return Size(width, maxChildHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    if (size.width <= 0 || size.height <= 0) return;
+    for (var i = 0; i < childElements.length; i++) {
+      if (i < _childOffsets.length) {
+        childElements[i].paint(buffer, offset + _childOffsets[i]);
+      }
     }
   }
 
@@ -1008,21 +1218,6 @@ class Column extends Widget {
   Element createElement() => ColumnElement(this);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
-    final constraints = children
-        .map((c) => _getConstraint(c, LayoutDirection.vertical))
-        .toList();
-    final rects = splitRect(area, constraints, LayoutDirection.vertical);
-    for (var i = 0; i < children.length; i++) {
-      final child = _getRealWidget(children[i]);
-      final childArea = rects[i];
-      final viewport = Viewport(buffer, childArea);
-      child.render(viewport, Rect(0, 0, childArea.width, childArea.height));
-    }
-  }
-
-  @override
   int getIntrinsicHeight(int width) {
     var totalHeight = 0;
     for (final child in children) {
@@ -1036,28 +1231,26 @@ class Column extends Widget {
 class ColumnElement extends Element {
   /// The list of managed child elements.
   List<Element> childElements = [];
+  List<Offset> _childOffsets = [];
 
   /// Creates a column element for a [Column] widget.
   ColumnElement(Column super.widget);
 
   @override
-  void unmount() {
-    for (final child in childElements) {
-      child.unmount();
-    }
-    super.unmount();
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
     final column = widget as Column;
-    if (area.width <= 0 || area.height <= 0) return;
-
-    final constraints = column.children
-        .map((c) => _getConstraint(c, LayoutDirection.vertical))
-        .toList();
-    final rects = splitRect(area, constraints, LayoutDirection.vertical);
-
     final newElements = <Element>[];
     for (var i = 0; i < column.children.length; i++) {
       final childWidget = column.children[i];
@@ -1078,12 +1271,59 @@ class ColumnElement extends Element {
       childElements[i].unmount();
     }
     childElements = newElements;
+  }
+
+  @override
+  void unmount() {
+    for (final child in childElements) {
+      child.unmount();
+    }
+    super.unmount();
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final column = widget as Column;
+    final width = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    final height = constraints.maxHeight == BoxConstraints.infinity
+        ? 0
+        : constraints.maxHeight;
+    final area = Rect(0, 0, width, height);
+
+    final columnConstraints = column.children
+        .map((c) => _getConstraint(c, LayoutDirection.vertical))
+        .toList();
+    final rects = splitRect(area, columnConstraints, LayoutDirection.vertical);
+
+    _childOffsets = List<Offset>.filled(childElements.length, Offset.zero);
+    var totalHeight = 0;
 
     for (var i = 0; i < childElements.length; i++) {
       final childEl = childElements[i];
       final childArea = rects[i];
-      final viewport = Viewport(buffer, childArea);
-      childEl.render(viewport, Rect(0, 0, childArea.width, childArea.height));
+      _childOffsets[i] = Offset(childArea.x, childArea.y);
+      final childSize = childEl.layout(
+        BoxConstraints(
+          minWidth: 0,
+          maxWidth: width,
+          minHeight: childArea.height,
+          maxHeight: childArea.height,
+        ),
+      );
+      totalHeight += childSize.height;
+    }
+    return Size(width, totalHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    if (size.width <= 0 || size.height <= 0) return;
+    for (var i = 0; i < childElements.length; i++) {
+      if (i < _childOffsets.length) {
+        childElements[i].paint(buffer, offset + _childOffsets[i]);
+      }
     }
   }
 
@@ -1105,68 +1345,6 @@ class Stack extends Widget {
   Element createElement() => StackElement(this);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
-    for (final child in children) {
-      if (child is Positioned) {
-        int childX = area.x;
-        int childY = area.y;
-        int childWidth = area.width;
-        int childHeight = area.height;
-
-        if (child.left != null) {
-          childX = area.x + child.left!;
-          if (child.right != null) {
-            childWidth = area.width - child.left! - child.right!;
-          } else if (child.width != null) {
-            childWidth = child.width!;
-          } else {
-            childWidth = area.width - child.left!;
-          }
-        } else if (child.right != null) {
-          if (child.width != null) {
-            childWidth = child.width!;
-            childX = area.x + area.width - child.right! - childWidth;
-          } else {
-            childWidth = area.width - child.right!;
-          }
-        } else if (child.width != null) {
-          childWidth = child.width!;
-        }
-
-        if (child.top != null) {
-          childY = area.y + child.top!;
-          if (child.bottom != null) {
-            childHeight = area.height - child.top! - child.bottom!;
-          } else if (child.height != null) {
-            childHeight = child.height!;
-          } else {
-            childHeight = area.height - child.top!;
-          }
-        } else if (child.bottom != null) {
-          if (child.height != null) {
-            childHeight = child.height!;
-            childY = area.y + area.height - child.bottom! - childHeight;
-          } else {
-            childHeight = area.height - child.bottom!;
-          }
-        } else if (child.height != null) {
-          childHeight = child.height!;
-        }
-
-        if (childWidth <= 0 || childHeight <= 0) continue;
-
-        final childArea = Rect(childX, childY, childWidth, childHeight);
-        final viewport = Viewport(buffer, childArea);
-        child.child.render(viewport, Rect(0, 0, childWidth, childHeight));
-      } else {
-        final viewport = Viewport(buffer, area);
-        child.render(viewport, Rect(0, 0, area.width, area.height));
-      }
-    }
-  }
-
-  @override
   int getIntrinsicHeight(int width) {
     var maxH = 0;
     for (final child in children) {
@@ -1181,15 +1359,26 @@ class Stack extends Widget {
 class StackElement extends Element {
   /// The list of managed child elements.
   List<Element> childElements = [];
+  List<Offset> _childOffsets = [];
 
   /// Creates a stack element for a [Stack] widget.
   StackElement(Stack super.widget);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final stack = widget as Stack;
-    if (area.width <= 0 || area.height <= 0) return;
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
 
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    final stack = widget as Stack;
     final newElements = <Element>[];
     for (var i = 0; i < stack.children.length; i++) {
       final childWidget = stack.children[i];
@@ -1198,71 +1387,119 @@ class StackElement extends Element {
         childElements[i].update(childWidget);
         newElements.add(childElements[i]);
       } else {
+        if (i < childElements.length) {
+          childElements[i].unmount();
+        }
         final newEl = childWidget.createElement();
         newEl.mount(this);
         newElements.add(newEl);
       }
     }
+    for (var i = stack.children.length; i < childElements.length; i++) {
+      childElements[i].unmount();
+    }
     childElements = newElements;
+  }
+
+  @override
+  void unmount() {
+    for (final child in childElements) {
+      child.unmount();
+    }
+    super.unmount();
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final width = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    final height = constraints.maxHeight == BoxConstraints.infinity
+        ? 0
+        : constraints.maxHeight;
+
+    _childOffsets = List<Offset>.filled(childElements.length, Offset.zero);
+
+    var maxW = 0;
+    var maxH = 0;
 
     for (var i = 0; i < childElements.length; i++) {
       final childEl = childElements[i];
       final childWidget = childEl.widget;
 
       if (childWidget is Positioned) {
-        int childX = area.x;
-        int childY = area.y;
-        int childWidth = area.width;
-        int childHeight = area.height;
+        int childX = 0;
+        int childY = 0;
+        int childWidth = width;
+        int childHeight = height;
 
         if (childWidget.left != null) {
-          childX = area.x + childWidget.left!;
+          childX = childWidget.left!;
           if (childWidget.right != null) {
-            childWidth = area.width - childWidget.left! - childWidget.right!;
+            childWidth = width - childWidget.left! - childWidget.right!;
           } else if (childWidget.width != null) {
             childWidth = childWidget.width!;
           } else {
-            childWidth = area.width - childWidget.left!;
+            childWidth = width - childWidget.left!;
           }
         } else if (childWidget.right != null) {
           if (childWidget.width != null) {
             childWidth = childWidget.width!;
-            childX = area.x + area.width - childWidget.right! - childWidth;
+            childX = width - childWidget.right! - childWidth;
           } else {
-            childWidth = area.width - childWidget.right!;
+            childWidth = width - childWidget.right!;
           }
         } else if (childWidget.width != null) {
           childWidth = childWidget.width!;
         }
 
         if (childWidget.top != null) {
-          childY = area.y + childWidget.top!;
+          childY = childWidget.top!;
           if (childWidget.bottom != null) {
-            childHeight = area.height - childWidget.top! - childWidget.bottom!;
+            childHeight = height - childWidget.top! - childWidget.bottom!;
           } else if (childWidget.height != null) {
             childHeight = childWidget.height!;
           } else {
-            childHeight = area.height - childWidget.top!;
+            childHeight = height - childWidget.top!;
           }
         } else if (childWidget.bottom != null) {
           if (childWidget.height != null) {
             childHeight = childWidget.height!;
-            childY = area.y + area.height - childWidget.bottom! - childHeight;
+            childY = height - childWidget.bottom! - childHeight;
           } else {
-            childHeight = area.height - childWidget.bottom!;
+            childHeight = height - childWidget.bottom!;
           }
         } else if (childWidget.height != null) {
           childHeight = childWidget.height!;
         }
 
-        if (childWidth <= 0 || childHeight <= 0) continue;
-
-        final childArea = Rect(childX, childY, childWidth, childHeight);
-        final viewport = Viewport(buffer, childArea);
-        childEl.render(viewport, Rect(0, 0, childWidth, childHeight));
+        _childOffsets[i] = Offset(childX, childY);
+        if (childWidth > 0 && childHeight > 0) {
+          final childSize = childEl.layout(
+            BoxConstraints.tight(Size(childWidth, childHeight)),
+          );
+          final rightEdge = childX + childSize.width;
+          final bottomEdge = childY + childSize.height;
+          if (rightEdge > maxW) maxW = rightEdge;
+          if (bottomEdge > maxH) maxH = bottomEdge;
+        }
       } else {
-        final viewport = Viewport(buffer, area);
-        childEl.render(viewport, Rect(0, 0, area.width, area.height));
+        _childOffsets[i] = Offset.zero;
+        final childSize = childEl.layout(constraints);
+        if (childSize.width > maxW) maxW = childSize.width;
+        if (childSize.height > maxH) maxH = childSize.height;
+      }
+    }
+
+    return Size(maxW, maxH);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    if (size.width <= 0 || size.height <= 0) return;
+    for (var i = 0; i < childElements.length; i++) {
+      if (i < _childOffsets.length) {
+        childElements[i].paint(buffer, offset + _childOffsets[i]);
       }
     }
   }
@@ -1311,11 +1548,6 @@ class Positioned extends Widget {
   Element createElement() => PositionedElement(this);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    child.render(buffer, area);
-  }
-
-  @override
   int getIntrinsicHeight(int width) {
     if (height != null) return height!;
     return child.getIntrinsicHeight(width);
@@ -1331,16 +1563,47 @@ class PositionedElement extends Element {
   PositionedElement(Positioned super.widget);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
     final pos = widget as Positioned;
     if (childElement != null &&
         childElement!.widget.runtimeType == pos.child.runtimeType) {
       childElement!.update(pos.child);
     } else {
+      childElement?.unmount();
       childElement = pos.child.createElement();
       childElement!.mount(this);
     }
-    childElement!.render(buffer, area);
+  }
+
+  @override
+  void unmount() {
+    childElement?.unmount();
+    super.unmount();
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    if (childElement != null) {
+      return childElement!.layout(constraints);
+    }
+    return constraints.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    childElement?.paint(buffer, offset);
   }
 
   @override
@@ -1370,20 +1633,6 @@ class SizedBox extends Widget {
   Element createElement() => SizedBoxElement(this);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final targetWidth = width ?? area.width;
-    final targetHeight = height ?? area.height;
-
-    if (targetWidth <= 0 || targetHeight <= 0) return;
-
-    if (child != null) {
-      final childArea = Rect(area.x, area.y, targetWidth, targetHeight);
-      final viewport = Viewport(buffer, childArea);
-      child!.render(viewport, Rect(0, 0, targetWidth, targetHeight));
-    }
-  }
-
-  @override
   int getIntrinsicHeight(int width) {
     if (height != null) return height!;
     if (child != null) {
@@ -1402,62 +1651,61 @@ class SizedBoxElement extends Element {
   SizedBoxElement(SizedBox super.widget);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
     final sb = widget as SizedBox;
-    final targetWidth = sb.width ?? area.width;
-    final targetHeight = sb.height ?? area.height;
-
-    if (targetWidth <= 0 || targetHeight <= 0) return;
-
     if (sb.child != null) {
       if (childElement != null &&
-          childElement!.widget.runtimeType == sb.child.runtimeType) {
+          childElement!.widget.runtimeType == sb.child!.runtimeType) {
         childElement!.update(sb.child!);
       } else {
+        childElement?.unmount();
         childElement = sb.child!.createElement();
         childElement!.mount(this);
       }
-
-      final childArea = Rect(area.x, area.y, targetWidth, targetHeight);
-      final viewport = Viewport(buffer, childArea);
-      childElement!.render(viewport, Rect(0, 0, targetWidth, targetHeight));
+    } else {
+      childElement?.unmount();
+      childElement = null;
     }
+  }
+
+  @override
+  void unmount() {
+    childElement?.unmount();
+    super.unmount();
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final sb = widget as SizedBox;
+    final tightened = constraints.tighten(width: sb.width, height: sb.height);
+    if (childElement != null) {
+      final childSize = childElement!.layout(tightened);
+      return childSize;
+    }
+    return tightened.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    childElement?.paint(buffer, offset);
   }
 
   @override
   void visitChildren(void Function(Element child) visitor) {
     if (childElement != null) visitor(childElement!);
   }
-}
-
-/// Immutable box layout constraints.
-class BoxConstraints {
-  /// The minimum width allowed.
-  final int minWidth;
-
-  /// The maximum width allowed.
-  final int maxWidth;
-
-  /// The minimum height allowed.
-  final int minHeight;
-
-  /// The maximum height allowed.
-  final int maxHeight;
-
-  /// Creates box constraints with the given limits.
-  const BoxConstraints({
-    this.minWidth = 0,
-    this.maxWidth = 999999,
-    this.minHeight = 0,
-    this.maxHeight = 999999,
-  });
-
-  /// Creates box constraints that require the given width or height.
-  const BoxConstraints.tightFor({int? width, int? height})
-    : minWidth = width ?? 0,
-      maxWidth = width ?? 999999,
-      minHeight = height ?? 0,
-      maxHeight = height ?? 999999;
 }
 
 /// A widget that imposes [BoxConstraints] on its child.
@@ -1473,24 +1721,6 @@ class ConstrainedBox extends Widget {
 
   @override
   Element createElement() => ConstrainedBoxElement(this);
-
-  @override
-  void render(Buffer buffer, Rect area) {
-    final clampedWidth = area.width.clamp(
-      constraints.minWidth,
-      constraints.maxWidth,
-    );
-    final clampedHeight = area.height.clamp(
-      constraints.minHeight,
-      constraints.maxHeight,
-    );
-
-    if (clampedWidth <= 0 || clampedHeight <= 0) return;
-
-    final childArea = Rect(area.x, area.y, clampedWidth, clampedHeight);
-    final viewport = Viewport(buffer, childArea);
-    child.render(viewport, Rect(0, 0, clampedWidth, clampedHeight));
-  }
 
   @override
   int getIntrinsicHeight(int width) {
@@ -1509,30 +1739,49 @@ class ConstrainedBoxElement extends Element {
   ConstrainedBoxElement(ConstrainedBox super.widget);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
     final cb = widget as ConstrainedBox;
-    final clampedWidth = area.width.clamp(
-      cb.constraints.minWidth,
-      cb.constraints.maxWidth,
-    );
-    final clampedHeight = area.height.clamp(
-      cb.constraints.minHeight,
-      cb.constraints.maxHeight,
-    );
-
-    if (clampedWidth <= 0 || clampedHeight <= 0) return;
-
     if (childElement != null &&
         childElement!.widget.runtimeType == cb.child.runtimeType) {
       childElement!.update(cb.child);
     } else {
+      childElement?.unmount();
       childElement = cb.child.createElement();
       childElement!.mount(this);
     }
+  }
 
-    final childArea = Rect(area.x, area.y, clampedWidth, clampedHeight);
-    final viewport = Viewport(buffer, childArea);
-    childElement!.render(viewport, Rect(0, 0, clampedWidth, clampedHeight));
+  @override
+  void unmount() {
+    childElement?.unmount();
+    super.unmount();
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final cb = widget as ConstrainedBox;
+    final childConstraints = constraints.enforce(cb.constraints);
+    if (childElement != null) {
+      return childElement!.layout(childConstraints);
+    }
+    return childConstraints.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    childElement?.paint(buffer, offset);
   }
 
   @override
@@ -1556,11 +1805,6 @@ class Flexible extends Widget {
   Element createElement() => FlexibleElement(this);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    child.render(buffer, area);
-  }
-
-  @override
   int getIntrinsicHeight(int width) {
     return child.getIntrinsicHeight(width);
   }
@@ -1575,16 +1819,47 @@ class FlexibleElement extends Element {
   FlexibleElement(Flexible super.widget);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
     final flex = widget as Flexible;
     if (childElement != null &&
         childElement!.widget.runtimeType == flex.child.runtimeType) {
       childElement!.update(flex.child);
     } else {
+      childElement?.unmount();
       childElement = flex.child.createElement();
       childElement!.mount(this);
     }
-    childElement!.render(buffer, area);
+  }
+
+  @override
+  void unmount() {
+    childElement?.unmount();
+    super.unmount();
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    if (childElement != null) {
+      return childElement!.layout(constraints);
+    }
+    return constraints.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    childElement?.paint(buffer, offset);
   }
 
   @override
@@ -1664,54 +1939,6 @@ class Align extends Widget {
   Element createElement() => AlignElement(this);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    int childWidth = area.width;
-    int childHeight = area.height;
-
-    if (child is SizedBox) {
-      final sb = child as SizedBox;
-      childWidth = sb.width ?? area.width;
-      childHeight = sb.height ?? area.height;
-    } else if (child is ConstrainedBox) {
-      final cb = child as ConstrainedBox;
-      childWidth = area.width.clamp(
-        cb.constraints.minWidth,
-        cb.constraints.maxWidth,
-      );
-      childHeight = area.height.clamp(
-        cb.constraints.minHeight,
-        cb.constraints.maxHeight,
-      );
-    }
-
-    if (widthFactor != null) {
-      childWidth = (childWidth * widthFactor!).round();
-    }
-    if (heightFactor != null) {
-      childHeight = (childHeight * heightFactor!).round();
-    }
-
-    childWidth = childWidth.clamp(0, area.width);
-    childHeight = childHeight.clamp(0, area.height);
-
-    final double remainingWidth = (area.width - childWidth).toDouble();
-    final int offsetX = (remainingWidth * (alignment.x + 1.0) / 2.0).round();
-
-    final double remainingHeight = (area.height - childHeight).toDouble();
-    final int offsetY = (remainingHeight * (alignment.y + 1.0) / 2.0).round();
-
-    final childArea = Rect(
-      area.x + offsetX,
-      area.y + offsetY,
-      childWidth,
-      childHeight,
-    );
-
-    final childViewport = Viewport(buffer, childArea);
-    child.render(childViewport, Rect(0, 0, childWidth, childHeight));
-  }
-
-  @override
   int getIntrinsicHeight(int width) {
     if (heightFactor != null) {
       return (child.getIntrinsicHeight(width) * heightFactor!).round();
@@ -1724,66 +1951,91 @@ class Align extends Widget {
 class AlignElement extends Element {
   /// The child element.
   Element? childElement;
+  Offset _childOffset = Offset.zero;
 
   /// Creates an align element for an [Align] widget.
   AlignElement(Align super.widget);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
     final align = widget as Align;
-    int childWidth = area.width;
-    int childHeight = area.height;
-
-    final childWidget = align.child;
-    if (childWidget is SizedBox) {
-      childWidth = childWidget.width ?? area.width;
-      childHeight = childWidget.height ?? area.height;
-    } else if (childWidget is ConstrainedBox) {
-      childWidth = area.width.clamp(
-        childWidget.constraints.minWidth,
-        childWidget.constraints.maxWidth,
-      );
-      childHeight = area.height.clamp(
-        childWidget.constraints.minHeight,
-        childWidget.constraints.maxHeight,
-      );
-    }
-
-    if (align.widthFactor != null) {
-      childWidth = (childWidth * align.widthFactor!).round();
-    }
-    if (align.heightFactor != null) {
-      childHeight = (childHeight * align.heightFactor!).round();
-    }
-
-    childWidth = childWidth.clamp(0, area.width);
-    childHeight = childHeight.clamp(0, area.height);
-
-    final double remainingWidth = (area.width - childWidth).toDouble();
-    final int offsetX = (remainingWidth * (align.alignment.x + 1.0) / 2.0)
-        .round();
-
-    final double remainingHeight = (area.height - childHeight).toDouble();
-    final int offsetY = (remainingHeight * (align.alignment.y + 1.0) / 2.0)
-        .round();
-
     if (childElement != null &&
-        childElement!.widget.runtimeType == childWidget.runtimeType) {
-      childElement!.update(childWidget);
+        childElement!.widget.runtimeType == align.child.runtimeType) {
+      childElement!.update(align.child);
     } else {
-      childElement = childWidget.createElement();
+      childElement?.unmount();
+      childElement = align.child.createElement();
       childElement!.mount(this);
     }
+  }
 
-    final childArea = Rect(
-      area.x + offsetX,
-      area.y + offsetY,
-      childWidth,
-      childHeight,
-    );
+  @override
+  void unmount() {
+    childElement?.unmount();
+    super.unmount();
+  }
 
-    final childViewport = Viewport(buffer, childArea);
-    childElement!.render(childViewport, Rect(0, 0, childWidth, childHeight));
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final align = widget as Align;
+    if (childElement != null) {
+      final childConstraints = BoxConstraints(
+        minWidth: 0,
+        maxWidth: constraints.maxWidth,
+        minHeight: 0,
+        maxHeight: constraints.maxHeight,
+      );
+      final childSize = childElement!.layout(childConstraints);
+
+      final parentWidth = align.widthFactor != null
+          ? (childSize.width * align.widthFactor!).round().clamp(
+              constraints.minWidth,
+              constraints.maxWidth,
+            )
+          : (constraints.maxWidth == BoxConstraints.infinity
+                ? childSize.width
+                : constraints.maxWidth);
+      final parentHeight = align.heightFactor != null
+          ? (childSize.height * align.heightFactor!).round().clamp(
+              constraints.minHeight,
+              constraints.maxHeight,
+            )
+          : (constraints.maxHeight == BoxConstraints.infinity
+                ? childSize.height
+                : constraints.maxHeight);
+
+      final childWidth = childSize.width.clamp(0, parentWidth);
+      final childHeight = childSize.height.clamp(0, parentHeight);
+
+      final double remainingWidth = (parentWidth - childWidth).toDouble();
+      final int offsetX = (remainingWidth * (align.alignment.x + 1.0) / 2.0)
+          .round();
+
+      final double remainingHeight = (parentHeight - childHeight).toDouble();
+      final int offsetY = (remainingHeight * (align.alignment.y + 1.0) / 2.0)
+          .round();
+
+      _childOffset = Offset(offsetX, offsetY);
+      return Size(parentWidth, parentHeight);
+    }
+    return constraints.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    childElement?.paint(buffer, offset + _childOffset);
   }
 
   @override
@@ -1815,14 +2067,22 @@ class ElementWidget extends Widget {
   Element? get element => _element;
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Element createElement() => ElementWidgetElement(this);
+
+  /// Resolves the layout of the embedded widget tree.
+  void layout(BoxConstraints constraints) {
     if (_element == null) {
       _element = child.createElement();
       _element!.mount(null);
     } else {
       _element!.update(child);
     }
-    _element!.render(buffer, area);
+    _element!.layout(constraints);
+  }
+
+  /// Paints the embedded widget tree.
+  void paint(Buffer buffer, Offset offset) {
+    _element?.paint(buffer, offset);
   }
 
   /// Finds a State of type S inside this widget's element tree.
@@ -1846,5 +2106,55 @@ class ElementWidget extends Widget {
       }
     });
     return found;
+  }
+}
+
+/// Element for [ElementWidget] that delegates layout, painting, and child lifecycle management.
+class ElementWidgetElement extends Element {
+  /// Creates a new [ElementWidgetElement].
+  ElementWidgetElement(ElementWidget super.widget);
+
+  @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    final w = widget as ElementWidget;
+    w._element ??= w.child.createElement();
+    w._element!.mount(this);
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    final w = widget as ElementWidget;
+    w._element?.update(w.child);
+  }
+
+  @override
+  void unmount() {
+    final w = widget as ElementWidget;
+    w._element?.unmount();
+    w._element = null;
+    super.unmount();
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final w = widget as ElementWidget;
+    if (w._element != null) {
+      return w._element!.layout(constraints);
+    }
+    return Size.zero;
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = widget as ElementWidget;
+    w._element?.paint(buffer, offset);
+  }
+
+  @override
+  void visitChildren(void Function(Element child) visitor) {
+    final w = widget as ElementWidget;
+    if (w._element != null) visitor(w._element!);
   }
 }

--- a/packages/termui/lib/ui/widget_toolkit.dart
+++ b/packages/termui/lib/ui/widget_toolkit.dart
@@ -40,3 +40,4 @@ export 'widgets/stateful_builder.dart';
 export 'widgets/prompt_runner.dart';
 export 'widgets/horizontal_radio_group.dart';
 export 'widgets/selection_controller.dart';
+export 'widgets/layout_builder.dart';

--- a/packages/termui/lib/ui/widgets/animated_button.dart
+++ b/packages/termui/lib/ui/widgets/animated_button.dart
@@ -155,9 +155,41 @@ class _AnimatedButtonRenderWidget extends Widget {
   const _AnimatedButtonRenderWidget(this.state);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final W = state.widget.width ?? area.width;
-    final H = state.widget.height ?? area.height;
+  Element createElement() => _AnimatedButtonElement(this);
+}
+
+class _AnimatedButtonElement extends Element {
+  _AnimatedButtonElement(_AnimatedButtonRenderWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final wWidget = widget as _AnimatedButtonRenderWidget;
+    final state = wWidget.state;
+    final w =
+        state.widget.width ??
+        (constraints.maxWidth == BoxConstraints.infinity
+            ? 0
+            : constraints.maxWidth);
+    final h =
+        state.widget.height ??
+        (constraints.maxHeight == BoxConstraints.infinity
+            ? 0
+            : constraints.maxHeight);
+    state._lastWidth = w;
+    state._lastHeight = h;
+    return constraints.constrain(Size(w, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final viewport = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
+    final wWidget = widget as _AnimatedButtonRenderWidget;
+    final state = wWidget.state;
+    final W = size.width;
+    final H = size.height;
     state._lastWidth = W;
     state._lastHeight = H;
 
@@ -165,7 +197,7 @@ class _AnimatedButtonRenderWidget extends Widget {
     final baseStyle = state.widget.style;
     for (var y = 0; y < H; y++) {
       for (var x = 0; x < W; x++) {
-        buffer.setCell(x, y, Cell(' ', baseStyle));
+        viewport.setCell(x, y, Cell(' ', baseStyle));
       }
     }
 
@@ -174,10 +206,9 @@ class _AnimatedButtonRenderWidget extends Widget {
     final textLen = chars.length;
     final startX = max(0, (W - textLen) ~/ 2);
     final startY = max(0, (H - 1) ~/ 2);
-    buffer.writeString(startX, startY, state.widget.text, baseStyle);
+    viewport.writeString(startX, startY, state.widget.text, baseStyle);
 
     // 3. Delegate overlays to the animation framework mixin.
-    // This overlays animation calculations on top of existing cells.
-    state.paintEffects(buffer, Rect(0, 0, W, H), baseStyle);
+    state.paintEffects(viewport, Rect(0, 0, W, H), baseStyle);
   }
 }

--- a/packages/termui/lib/ui/widgets/canvas.dart
+++ b/packages/termui/lib/ui/widgets/canvas.dart
@@ -865,68 +865,7 @@ class Canvas extends Widget {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    Tracer.record(_traceCanvasRenderId, Phase.begin);
-    try {
-      var currentBuffer = buffer;
-      var startX = 0;
-      var startY = 0;
-      while (currentBuffer is Viewport) {
-        startX += currentBuffer.bounds.x;
-        startY += currentBuffer.bounds.y;
-        currentBuffer = currentBuffer.parent;
-      }
-      final targetBuffer = currentBuffer;
-
-      final targetWidth = targetBuffer.width;
-      final targetHeight = targetBuffer.height;
-      final targetCells = targetBuffer.cells;
-
-      for (var cy = 0; cy < height; cy++) {
-        final ty = startY + cy;
-        if (ty < 0 || ty >= targetHeight) continue;
-
-        for (var cx = 0; cx < width; cx++) {
-          final tx = startX + cx;
-          if (tx < 0 || tx >= targetWidth) continue;
-
-          if (isOccluded != null && isOccluded!(cx, cy)) continue;
-
-          final idx = cy * width + cx;
-          final dots = _grid[idx];
-          if (dots == 0 && _styles[idx] == null && style == Style.empty) {
-            continue;
-          }
-
-          final String char;
-          if (renderMode == CanvasRenderMode.quadrants) {
-            char = _quadrantCache[dots];
-          } else if (renderMode == CanvasRenderMode.density ||
-              _antiAliased[idx] == 1) {
-            char = _densityCache[dots];
-          } else {
-            char = _brailleCache[dots];
-          }
-
-          final targetIdx = ty * targetWidth + tx;
-          final cell = targetCells[targetIdx];
-          cell.char = char;
-          final s = _styles[idx];
-          if (s != null) {
-            cell.style = Style(
-              foreground: s.foreground ?? style.foreground,
-              background: s.background ?? style.background,
-              modifiers: s.modifiers | style.modifiers,
-            );
-          } else {
-            cell.style = style;
-          }
-        }
-      }
-    } finally {
-      Tracer.record(_traceCanvasRenderId, Phase.end);
-    }
-  }
+  Element createElement() => CanvasElement(this);
 
   // Pre-computed constants and cache tables for maximum rendering performance
   static const List<int> _dotMasks = [
@@ -997,4 +936,95 @@ class Canvas extends Widget {
     final index = (tl ? 1 : 0) | (tr ? 2 : 0) | (bl ? 4 : 0) | (br ? 8 : 0);
     return _quadrants[index];
   });
+}
+
+/// Element for high-performance direct flat-buffer rendering in [Canvas].
+class CanvasElement extends Element {
+  /// Instantiates the rendering element for the given Canvas.
+  CanvasElement(Canvas super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final canvas = widget as Canvas;
+    final width = constraints.hasBoundedWidth
+        ? constraints.maxWidth
+        : canvas.width;
+    final height = constraints.hasBoundedHeight
+        ? constraints.maxHeight
+        : canvas.height;
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final canvas = widget as Canvas;
+    Tracer.record(Canvas._traceCanvasRenderId, Phase.begin);
+    try {
+      var currentBuffer = buffer;
+      var startX = offset.dx;
+      var startY = offset.dy;
+      while (currentBuffer is Viewport) {
+        startX += currentBuffer.bounds.x;
+        startY += currentBuffer.bounds.y;
+        currentBuffer = currentBuffer.parent;
+      }
+      final targetBuffer = currentBuffer;
+
+      final targetWidth = targetBuffer.width;
+      final targetHeight = targetBuffer.height;
+      final targetCells = targetBuffer.cells;
+
+      final w = size.width;
+      final h = size.height;
+
+      final drawWidth = min(w, canvas.width);
+      final drawHeight = min(h, canvas.height);
+
+      for (var cy = 0; cy < drawHeight; cy++) {
+        final ty = startY + cy;
+        if (ty < 0 || ty >= targetHeight) continue;
+
+        for (var cx = 0; cx < drawWidth; cx++) {
+          final tx = startX + cx;
+          if (tx < 0 || tx >= targetWidth) continue;
+
+          if (canvas.isOccluded != null && canvas.isOccluded!(cx, cy)) continue;
+
+          final idx = cy * canvas.width + cx;
+          final dots = canvas._grid[idx];
+          if (dots == 0 &&
+              canvas._styles[idx] == null &&
+              canvas.style == Style.empty) {
+            continue;
+          }
+
+          final String char;
+          if (canvas.renderMode == CanvasRenderMode.quadrants) {
+            char = Canvas._quadrantCache[dots];
+          } else if (canvas.renderMode == CanvasRenderMode.density ||
+              canvas._antiAliased[idx] == 1) {
+            char = Canvas._densityCache[dots];
+          } else {
+            char = Canvas._brailleCache[dots];
+          }
+
+          final targetIdx = ty * targetWidth + tx;
+          final cell = targetCells[targetIdx];
+          cell.char = char;
+          final s = canvas._styles[idx];
+          if (s != null) {
+            cell.style = Style(
+              foreground: s.foreground ?? canvas.style.foreground,
+              background: s.background ?? canvas.style.background,
+              modifiers: s.modifiers | canvas.style.modifiers,
+            );
+          } else {
+            cell.style = canvas.style;
+          }
+        }
+      }
+    } finally {
+      Tracer.record(Canvas._traceCanvasRenderId, Phase.end);
+    }
+  }
 }

--- a/packages/termui/lib/ui/widgets/decorated_box.dart
+++ b/packages/termui/lib/ui/widgets/decorated_box.dart
@@ -200,113 +200,6 @@ class DecoratedBox extends Widget {
 
   @override
   Element createElement() => DecoratedBoxElement(this);
-
-  @override
-  void render(Buffer buffer, Rect area) {
-    // Fill background if defined
-    var bgStyle = decoration.backgroundStyle;
-    if (bgStyle == null && decoration.backgroundColor != null) {
-      bgStyle = Style(background: decoration.backgroundColor);
-    }
-    if (bgStyle != null) {
-      for (var y = 0; y < area.height; y++) {
-        for (var x = 0; x < area.width; x++) {
-          buffer.setCell(area.x + x, area.y + y, Cell(' ', bgStyle));
-        }
-      }
-    }
-
-    // Draw border if defined
-    final border = decoration.border;
-    var topOffset = 0;
-    var bottomOffset = 0;
-    var leftOffset = 0;
-    var rightOffset = 0;
-
-    if (border != null) {
-      final style = bgStyle != null
-          ? bgStyle.merge(border.style)
-          : border.style;
-
-      // Draw horizontal lines (excluding corners)
-      if (border.topChar.isNotEmpty && area.height > 0) {
-        topOffset = 1;
-        for (var x = 1; x < area.width - 1; x++) {
-          buffer.setCell(area.x + x, area.y, Cell(border.topChar, style));
-        }
-      }
-      if (border.bottomChar.isNotEmpty && area.height > 1) {
-        bottomOffset = 1;
-        for (var x = 1; x < area.width - 1; x++) {
-          buffer.setCell(
-            area.x + x,
-            area.y + area.height - 1,
-            Cell(border.bottomChar, style),
-          );
-        }
-      }
-
-      // Draw vertical lines (excluding corners)
-      if (border.leftChar.isNotEmpty && area.width > 0) {
-        leftOffset = 1;
-        for (var y = 1; y < area.height - 1; y++) {
-          buffer.setCell(area.x, area.y + y, Cell(border.leftChar, style));
-        }
-      }
-      if (border.rightChar.isNotEmpty && area.width > 1) {
-        rightOffset = 1;
-        for (var y = 1; y < area.height - 1; y++) {
-          buffer.setCell(
-            area.x + area.width - 1,
-            area.y + y,
-            Cell(border.rightChar, style),
-          );
-        }
-      }
-
-      // Draw corners
-      if (border.topLeftChar.isNotEmpty && area.width > 0 && area.height > 0) {
-        buffer.setCell(area.x, area.y, Cell(border.topLeftChar, style));
-      }
-      if (border.topRightChar.isNotEmpty && area.width > 1 && area.height > 0) {
-        buffer.setCell(
-          area.x + area.width - 1,
-          area.y,
-          Cell(border.topRightChar, style),
-        );
-      }
-      if (border.bottomLeftChar.isNotEmpty &&
-          area.width > 0 &&
-          area.height > 1) {
-        buffer.setCell(
-          area.x,
-          area.y + area.height - 1,
-          Cell(border.bottomLeftChar, style),
-        );
-      }
-      if (border.bottomRightChar.isNotEmpty &&
-          area.width > 1 &&
-          area.height > 1) {
-        buffer.setCell(
-          area.x + area.width - 1,
-          area.y + area.height - 1,
-          Cell(border.bottomRightChar, style),
-        );
-      }
-    }
-
-    // Render child in remaining area
-    final childX = area.x + leftOffset;
-    final childY = area.y + topOffset;
-    final childWidth = area.width - leftOffset - rightOffset;
-    final childHeight = area.height - topOffset - bottomOffset;
-
-    if (childWidth > 0 && childHeight > 0) {
-      final childArea = Rect(childX, childY, childWidth, childHeight);
-      final childViewport = Viewport(buffer, childArea);
-      child.render(childViewport, Rect(0, 0, childWidth, childHeight));
-    }
-  }
 }
 
 /// Element for [DecoratedBox].
@@ -314,12 +207,107 @@ class DecoratedBoxElement extends Element {
   /// The element corresponding to the [DecoratedBox]'s child.
   Element? childElement;
 
+  int _cachedTopOffset = 0;
+  int _cachedBottomOffset = 0;
+  int _cachedLeftOffset = 0;
+  int _cachedRightOffset = 0;
+
   /// Creates a new [DecoratedBoxElement].
   DecoratedBoxElement(DecoratedBox super.widget);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
     final db = widget as DecoratedBox;
+    if (childElement != null &&
+        childElement!.widget.runtimeType == db.child.runtimeType) {
+      childElement!.update(db.child);
+    } else {
+      childElement?.unmount();
+      childElement = db.child.createElement();
+      childElement!.mount(this);
+    }
+  }
+
+  @override
+  void unmount() {
+    childElement?.unmount();
+    super.unmount();
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final db = widget as DecoratedBox;
+    final border = db.decoration.border;
+
+    _cachedTopOffset = 0;
+    _cachedBottomOffset = 0;
+    _cachedLeftOffset = 0;
+    _cachedRightOffset = 0;
+
+    if (border != null) {
+      if (border.topChar.isNotEmpty) {
+        _cachedTopOffset = 1;
+      }
+      if (border.bottomChar.isNotEmpty) {
+        _cachedBottomOffset = 1;
+      }
+      if (border.leftChar.isNotEmpty) {
+        _cachedLeftOffset = 1;
+      }
+      if (border.rightChar.isNotEmpty) {
+        _cachedRightOffset = 1;
+      }
+    }
+
+    final doubleWidth = _cachedLeftOffset + _cachedRightOffset;
+    final doubleHeight = _cachedTopOffset + _cachedBottomOffset;
+
+    final childConstraints = BoxConstraints(
+      minWidth: constraints.minWidth - doubleWidth < 0
+          ? 0
+          : constraints.minWidth - doubleWidth,
+      maxWidth: constraints.maxWidth == BoxConstraints.infinity
+          ? BoxConstraints.infinity
+          : (constraints.maxWidth - doubleWidth < 0
+                ? 0
+                : constraints.maxWidth - doubleWidth),
+      minHeight: constraints.minHeight - doubleHeight < 0
+          ? 0
+          : constraints.minHeight - doubleHeight,
+      maxHeight: constraints.maxHeight == BoxConstraints.infinity
+          ? BoxConstraints.infinity
+          : (constraints.maxHeight - doubleHeight < 0
+                ? 0
+                : constraints.maxHeight - doubleHeight),
+    );
+
+    if (childElement != null) {
+      final childSize = childElement!.layout(childConstraints);
+      return Size(
+        childSize.width + doubleWidth,
+        childSize.height + doubleHeight,
+      );
+    }
+
+    return Size(doubleWidth, doubleHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final db = widget as DecoratedBox;
+    final area = Rect(offset.dx, offset.dy, size.width, size.height);
 
     // Fill background if defined
     var bgStyle = db.decoration.backgroundStyle;
@@ -336,10 +324,6 @@ class DecoratedBoxElement extends Element {
 
     // Draw border if defined
     final border = db.decoration.border;
-    var topOffset = 0;
-    var bottomOffset = 0;
-    var leftOffset = 0;
-    var rightOffset = 0;
 
     if (border != null) {
       final style = bgStyle != null
@@ -348,13 +332,11 @@ class DecoratedBoxElement extends Element {
 
       // Draw horizontal lines (excluding corners)
       if (border.topChar.isNotEmpty && area.height > 0) {
-        topOffset = 1;
         for (var x = 1; x < area.width - 1; x++) {
           buffer.setCell(area.x + x, area.y, Cell(border.topChar, style));
         }
       }
       if (border.bottomChar.isNotEmpty && area.height > 1) {
-        bottomOffset = 1;
         for (var x = 1; x < area.width - 1; x++) {
           buffer.setCell(
             area.x + x,
@@ -366,13 +348,11 @@ class DecoratedBoxElement extends Element {
 
       // Draw vertical lines (excluding corners)
       if (border.leftChar.isNotEmpty && area.width > 0) {
-        leftOffset = 1;
         for (var y = 1; y < area.height - 1; y++) {
           buffer.setCell(area.x, area.y + y, Cell(border.leftChar, style));
         }
       }
       if (border.rightChar.isNotEmpty && area.width > 1) {
-        rightOffset = 1;
         for (var y = 1; y < area.height - 1; y++) {
           buffer.setCell(
             area.x + area.width - 1,
@@ -413,23 +393,9 @@ class DecoratedBoxElement extends Element {
       }
     }
 
-    final childX = area.x + leftOffset;
-    final childY = area.y + topOffset;
-    final childWidth = area.width - leftOffset - rightOffset;
-    final childHeight = area.height - topOffset - bottomOffset;
-
-    if (childWidth > 0 && childHeight > 0) {
-      if (childElement != null &&
-          childElement!.widget.runtimeType == db.child.runtimeType) {
-        childElement!.update(db.child);
-      } else {
-        childElement = db.child.createElement();
-        childElement!.mount(this);
-      }
-
-      final childArea = Rect(childX, childY, childWidth, childHeight);
-      final childViewport = Viewport(buffer, childArea);
-      childElement!.render(childViewport, Rect(0, 0, childWidth, childHeight));
+    if (childElement != null) {
+      final childOffset = Offset(_cachedLeftOffset, _cachedTopOffset);
+      childElement!.paint(buffer, offset + childOffset);
     }
   }
 

--- a/packages/termui/lib/ui/widgets/form.dart
+++ b/packages/termui/lib/ui/widgets/form.dart
@@ -1,4 +1,3 @@
-import '../buffer.dart';
 import '../layout.dart';
 import '../style.dart';
 import '../color.dart';
@@ -551,14 +550,14 @@ class _TextFormFieldState extends FormFieldState<String>
   }
 }
 
-class _TextFormFieldRenderWidget extends Widget {
+class _TextFormFieldRenderWidget extends StatelessWidget {
   final TextFormField widget;
   final _TextFormFieldState state;
 
   const _TextFormFieldRenderWidget(this.widget, this.state);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Widget build(BuildContext context) {
     widget._input.focused = widget.focused;
     if (widget._input.value != state.value) {
       widget._input.value = state.value ?? '';
@@ -608,8 +607,7 @@ class _TextFormFieldRenderWidget extends Widget {
         ),
     ];
 
-    final vbox = Column(layoutItems);
-    vbox.render(buffer, area);
+    return Column(layoutItems);
   }
 }
 
@@ -691,14 +689,14 @@ class _TextAreaFormFieldState extends FormFieldState<String>
   }
 }
 
-class _TextAreaFormFieldRenderWidget extends Widget {
+class _TextAreaFormFieldRenderWidget extends StatelessWidget {
   final TextAreaFormField widget;
   final _TextAreaFormFieldState state;
 
   const _TextAreaFormFieldRenderWidget(this.widget, this.state);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Widget build(BuildContext context) {
     widget._input.focused = widget.focused;
     if (widget._input.value != state.value) {
       widget._input.value = state.value ?? '';
@@ -748,8 +746,7 @@ class _TextAreaFormFieldRenderWidget extends Widget {
         ),
     ];
 
-    final vbox = Column(layoutItems);
-    vbox.render(buffer, area);
+    return Column(layoutItems);
   }
 }
 
@@ -863,14 +860,14 @@ class _SelectFormFieldState<T> extends FormFieldState<T>
   }
 }
 
-class _SelectFormFieldRenderWidget<T> extends Widget {
+class _SelectFormFieldRenderWidget<T> extends StatelessWidget {
   final SelectFormField<T> widget;
   final _SelectFormFieldState<T> state;
 
   const _SelectFormFieldRenderWidget(this.widget, this.state);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Widget build(BuildContext context) {
     final optionItems = <Widget>[];
 
     for (var i = 0; i < widget.options.length; i++) {
@@ -936,8 +933,7 @@ class _SelectFormFieldRenderWidget<T> extends Widget {
         ),
     ];
 
-    final vbox = Column(layoutItems);
-    vbox.render(buffer, area);
+    return Column(layoutItems);
   }
 }
 
@@ -1003,14 +999,14 @@ class _ConfirmFormFieldState extends FormFieldState<bool>
   }
 }
 
-class _ConfirmFormFieldRenderWidget extends Widget {
+class _ConfirmFormFieldRenderWidget extends StatelessWidget {
   final ConfirmFormField widget;
   final _ConfirmFormFieldState state;
 
   const _ConfirmFormFieldRenderWidget(this.widget, this.state);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Widget build(BuildContext context) {
     final isYes = state.value ?? false;
 
     final yesStyle = isYes
@@ -1081,8 +1077,7 @@ class _ConfirmFormFieldRenderWidget extends Widget {
         ),
     ];
 
-    final vbox = Column(layoutItems);
-    vbox.render(buffer, area);
+    return Column(layoutItems);
   }
 }
 
@@ -1208,14 +1203,14 @@ class _MultiSelectFormFieldState<T> extends FormFieldState<List<T>>
   }
 }
 
-class _MultiSelectFormFieldRenderWidget<T> extends Widget {
+class _MultiSelectFormFieldRenderWidget<T> extends StatelessWidget {
   final MultiSelectFormField<T> widget;
   final _MultiSelectFormFieldState<T> state;
 
   const _MultiSelectFormFieldRenderWidget(this.widget, this.state);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Widget build(BuildContext context) {
     final optionItems = <Widget>[];
 
     for (var i = 0; i < widget.options.length; i++) {
@@ -1283,7 +1278,6 @@ class _MultiSelectFormFieldRenderWidget<T> extends Widget {
         ),
     ];
 
-    final vbox = Column(layoutItems);
-    vbox.render(buffer, area);
+    return Column(layoutItems);
   }
 }

--- a/packages/termui/lib/ui/widgets/grid.dart
+++ b/packages/termui/lib/ui/widgets/grid.dart
@@ -28,13 +28,41 @@ class Grid extends Widget {
   Grid(this.tiles);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    for (var y = 0; y < tiles.length; y++) {
-      if (y >= area.height) break;
-      final row = tiles[y];
+  Element createElement() => GridElement(this);
+}
+
+/// Element class that manages layout and paint of [Grid].
+class GridElement extends Element {
+  /// Calculated width of the grid from tiles.
+  int calculatedWidth = 0;
+
+  /// Calculated height of the grid from tiles.
+  int calculatedHeight = 0;
+
+  /// Instantiates the rendering element for the given Grid.
+  GridElement(Grid super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final grid = widget as Grid;
+    calculatedHeight = grid.tiles.length;
+    calculatedWidth = calculatedHeight > 0 ? grid.tiles[0].length : 0;
+
+    return constraints.constrain(Size(calculatedWidth, calculatedHeight));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final grid = widget as Grid;
+    final w = size.width;
+    final h = size.height;
+
+    for (var y = 0; y < grid.tiles.length; y++) {
+      if (y >= h) break;
+      final row = grid.tiles[y];
       for (var x = 0; x < row.length; x++) {
-        if (x >= area.width) break;
-        final cell = buffer.getCell(x, y);
+        if (x >= w) break;
+        final cell = buffer.getCell(offset.dx + x, offset.dy + y);
         if (cell != null) {
           cell.char = row[x].char;
           cell.style = row[x].style;

--- a/packages/termui/lib/ui/widgets/help.dart
+++ b/packages/termui/lib/ui/widgets/help.dart
@@ -57,18 +57,80 @@ class Help extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (bindings.isEmpty || area.width <= 0 || area.height <= 0) return;
+  Element createElement() => HelpElement(this);
+}
+
+/// An element that manages the layout and rendering of a [Help] widget.
+class HelpElement extends Element {
+  /// Creates a [HelpElement] for the given [widget].
+  HelpElement(Help super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final help = widget as Help;
+    final maxWidth = constraints.maxWidth == BoxConstraints.infinity
+        ? 999999
+        : constraints.maxWidth;
+
+    if (help.bindings.isEmpty || maxWidth <= 0) {
+      return constraints.constrain(Size.zero);
+    }
 
     final items = <_HelpItem>[];
-    for (final entry in bindings.entries) {
+    for (final entry in help.bindings.entries) {
+      items.add(_HelpItem(entry.key, entry.value));
+    }
+
+    var currentLineY = 1;
+    var currentLineX = 0;
+    final separatorChars = help.separator.characters;
+
+    for (var i = 0; i < items.length; i++) {
+      final item = items[i];
+      final itemLength =
+          item.key.characters.length + 1 + item.desc.characters.length;
+      final isLast = i == items.length - 1;
+
+      if (currentLineX + itemLength > maxWidth && currentLineX > 0) {
+        currentLineY++;
+        currentLineX = 0;
+      }
+
+      currentLineX += itemLength;
+
+      if (!isLast) {
+        if (currentLineX + separatorChars.length <= maxWidth) {
+          currentLineX += separatorChars.length;
+        } else {
+          currentLineY++;
+          currentLineX = 0;
+        }
+      }
+    }
+
+    final resolvedWidth = constraints.maxWidth == BoxConstraints.infinity
+        ? currentLineX
+        : constraints.maxWidth;
+    return constraints.constrain(Size(resolvedWidth, currentLineY));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final viewport = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
+    final help = widget as Help;
+    if (help.bindings.isEmpty || size.width <= 0 || size.height <= 0) return;
+
+    final items = <_HelpItem>[];
+    for (final entry in help.bindings.entries) {
       items.add(_HelpItem(entry.key, entry.value));
     }
 
     var currentLineY = 0;
     var currentLineX = 0;
-
-    final separatorChars = separator.characters;
+    final separatorChars = help.separator.characters;
 
     for (var i = 0; i < items.length; i++) {
       final item = items[i];
@@ -78,37 +140,40 @@ class Help extends Widget {
       final descPartChars = descPart.characters;
       final isLast = i == items.length - 1;
 
-      // Calculate the length of "key desc" + separator (if not last)
       final itemLength = keyPartChars.length + 1 + descPartChars.length;
 
-      // Wrap to next line if it doesn't fit on the current line
-      if (currentLineX + itemLength > area.width && currentLineX > 0) {
+      if (currentLineX + itemLength > size.width && currentLineX > 0) {
         currentLineY++;
         currentLineX = 0;
       }
 
-      if (currentLineY >= area.height) break;
+      if (currentLineY >= size.height) break;
 
       // Render key
-      buffer.writeString(currentLineX, currentLineY, keyPart, keyStyle);
+      viewport.writeString(currentLineX, currentLineY, keyPart, help.keyStyle);
       currentLineX += keyPartChars.length;
 
       // Render space
-      buffer.writeString(currentLineX, currentLineY, ' ', Style.empty);
+      viewport.writeString(currentLineX, currentLineY, ' ', Style.empty);
       currentLineX += 1;
 
       // Render description
-      buffer.writeString(currentLineX, currentLineY, descPart, descStyle);
+      viewport.writeString(
+        currentLineX,
+        currentLineY,
+        descPart,
+        help.descStyle,
+      );
       currentLineX += descPartChars.length;
 
       // Render separator
       if (!isLast) {
-        if (currentLineX + separatorChars.length <= area.width) {
-          buffer.writeString(
+        if (currentLineX + separatorChars.length <= size.width) {
+          viewport.writeString(
             currentLineX,
             currentLineY,
-            separator,
-            separatorStyle,
+            help.separator,
+            help.separatorStyle,
           );
           currentLineX += separatorChars.length;
         } else {

--- a/packages/termui/lib/ui/widgets/inkwell_button.dart
+++ b/packages/termui/lib/ui/widgets/inkwell_button.dart
@@ -240,7 +240,39 @@ class _InkwellButtonRenderWidget extends Widget {
   const _InkwellButtonRenderWidget(this.state);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    state._render(buffer, area);
+  Element createElement() => _InkwellButtonElement(this);
+}
+
+class _InkwellButtonElement extends Element {
+  _InkwellButtonElement(_InkwellButtonRenderWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final wWidget = widget as _InkwellButtonRenderWidget;
+    final state = wWidget.state;
+    final w =
+        state.widget.width ??
+        (constraints.maxWidth == BoxConstraints.infinity
+            ? 0
+            : constraints.maxWidth);
+    final h =
+        state.widget.height ??
+        (constraints.maxHeight == BoxConstraints.infinity
+            ? 0
+            : constraints.maxHeight);
+    state._lastWidth = w;
+    state._lastHeight = h;
+    return constraints.constrain(Size(w, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final viewport = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
+    final wWidget = widget as _InkwellButtonRenderWidget;
+    final state = wWidget.state;
+    state._render(viewport, Rect(0, 0, size.width, size.height));
   }
 }

--- a/packages/termui/lib/ui/widgets/interactive_widgets.dart
+++ b/packages/termui/lib/ui/widgets/interactive_widgets.dart
@@ -7,6 +7,7 @@ import '../../terminal/terminal.dart' as term;
 import 'prompt_runner.dart';
 import 'focus.dart';
 import '../window.dart';
+import 'package:characters/characters.dart';
 
 /// An interactive TUI button widget that triggers a callback when activated.
 class Button extends StatefulWidget implements Focusable, KeyEventHandler {
@@ -146,10 +147,33 @@ class _ButtonRenderWidget extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
-    final label = focused ? '[ $text ]' : '  $text  ';
-    buffer.writeString(0, 0, label, focused ? focusedStyle : style);
+  Element createElement() => _ButtonElement(this);
+}
+
+class _ButtonElement extends Element {
+  _ButtonElement(_ButtonRenderWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final wWidget = widget as _ButtonRenderWidget;
+    final label = wWidget.focused
+        ? '[ ${wWidget.text} ]'
+        : '  ${wWidget.text}  ';
+    return constraints.constrain(Size(label.characters.length, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final wWidget = widget as _ButtonRenderWidget;
+    final label = wWidget.focused
+        ? '[ ${wWidget.text} ]'
+        : '  ${wWidget.text}  ';
+    buffer.writeString(
+      offset.dx,
+      offset.dy,
+      label,
+      wWidget.focused ? wWidget.focusedStyle : wWidget.style,
+    );
   }
 }
 
@@ -298,10 +322,31 @@ class _CheckboxRenderWidget extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
-    final box = value ? '[X]' : '[ ]';
-    buffer.writeString(0, 0, '$box $label', focused ? focusedStyle : style);
+  Element createElement() => _CheckboxElement(this);
+}
+
+class _CheckboxElement extends Element {
+  _CheckboxElement(_CheckboxRenderWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final wWidget = widget as _CheckboxRenderWidget;
+    final box = wWidget.value ? '[X]' : '[ ]';
+    final label = '$box ${wWidget.label}';
+    return constraints.constrain(Size(label.characters.length, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final wWidget = widget as _CheckboxRenderWidget;
+    final box = wWidget.value ? '[X]' : '[ ]';
+    final label = '$box ${wWidget.label}';
+    buffer.writeString(
+      offset.dx,
+      offset.dy,
+      label,
+      wWidget.focused ? wWidget.focusedStyle : wWidget.style,
+    );
   }
 }
 
@@ -457,10 +502,31 @@ class _RadioRenderWidget extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
-    final marker = isSelected ? '(*)' : '( )';
-    buffer.writeString(0, 0, '$marker $label', focused ? focusedStyle : style);
+  Element createElement() => _RadioElement(this);
+}
+
+class _RadioElement extends Element {
+  _RadioElement(_RadioRenderWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final wWidget = widget as _RadioRenderWidget;
+    final marker = wWidget.isSelected ? '(*)' : '( )';
+    final label = '$marker ${wWidget.label}';
+    return constraints.constrain(Size(label.characters.length, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final wWidget = widget as _RadioRenderWidget;
+    final marker = wWidget.isSelected ? '(*)' : '( )';
+    final label = '$marker ${wWidget.label}';
+    buffer.writeString(
+      offset.dx,
+      offset.dy,
+      label,
+      wWidget.focused ? wWidget.focusedStyle : wWidget.style,
+    );
   }
 }
 
@@ -609,9 +675,30 @@ class _SwitchRenderWidget extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
-    final marker = value ? '[─●]' : '[○─]';
-    buffer.writeString(0, 0, '$marker $label', focused ? focusedStyle : style);
+  Element createElement() => _SwitchElement(this);
+}
+
+class _SwitchElement extends Element {
+  _SwitchElement(_SwitchRenderWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final wWidget = widget as _SwitchRenderWidget;
+    final marker = wWidget.value ? '[─●]' : '[○─]';
+    final label = '$marker ${wWidget.label}';
+    return constraints.constrain(Size(label.characters.length, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final wWidget = widget as _SwitchRenderWidget;
+    final marker = wWidget.value ? '[─●]' : '[○─]';
+    final label = '$marker ${wWidget.label}';
+    buffer.writeString(
+      offset.dx,
+      offset.dy,
+      label,
+      wWidget.focused ? wWidget.focusedStyle : wWidget.style,
+    );
   }
 }

--- a/packages/termui/lib/ui/widgets/layout_builder.dart
+++ b/packages/termui/lib/ui/widgets/layout_builder.dart
@@ -1,0 +1,89 @@
+import '../buffer.dart';
+import '../layout.dart';
+
+/// Signature for the builder callback used by [LayoutBuilder].
+typedef LayoutWidgetBuilder =
+    Widget Function(BuildContext context, BoxConstraints constraints);
+
+/// A widget that builds a subtree based on the incoming layout constraints.
+class LayoutBuilder extends Widget {
+  /// The builder function that constructs the child widget.
+  final LayoutWidgetBuilder builder;
+
+  /// Creates a [LayoutBuilder].
+  const LayoutBuilder({super.key, required this.builder});
+
+  @override
+  Element createElement() => LayoutBuilderElement(this);
+}
+
+/// The element that manages the lifecycle of a [LayoutBuilder].
+class LayoutBuilderElement extends Element {
+  Element? _child;
+
+  /// Creates a layout builder element.
+  LayoutBuilderElement(LayoutBuilder super.widget);
+
+  @override
+  void visitChildren(void Function(Element child) visitor) {
+    if (_child != null) {
+      visitor(_child!);
+    }
+  }
+
+  @override
+  void unmount() {
+    _child?.unmount();
+    super.unmount();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    if (constraints != null) {
+      final builderWidget = widget as LayoutBuilder;
+      final childWidget = builderWidget.builder(this, constraints!);
+      if (_child != null &&
+          _child!.widget.runtimeType == childWidget.runtimeType) {
+        _child!.update(childWidget);
+      } else {
+        _child?.unmount();
+        _child = childWidget.createElement();
+        _child!.mount(this);
+      }
+      _child!.layout(constraints!);
+    }
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final builderWidget = widget as LayoutBuilder;
+
+    // 1. Build Phase: Invoke builder callback using incoming constraints
+    final childWidget = builderWidget.builder(this, constraints);
+
+    // 2. Reconciliation Phase: Mount or update child element
+    if (_child != null &&
+        _child!.widget.runtimeType == childWidget.runtimeType) {
+      _child!.update(childWidget);
+    } else {
+      _child?.unmount();
+      _child = childWidget.createElement();
+      _child!.mount(this);
+    }
+
+    // 3. Child Layout Phase: Run layout recursively on the child element tree
+    final childSize = _child!.layout(constraints);
+    return childSize;
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    _child?.paint(buffer, offset);
+  }
+}

--- a/packages/termui/lib/ui/widgets/lazy_table.dart
+++ b/packages/termui/lib/ui/widgets/lazy_table.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'package:characters/characters.dart';
 import '../buffer.dart';
 import '../layout.dart';
@@ -22,19 +23,118 @@ class LazyList extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0 || itemCount <= 0) return;
+  Element createElement() => LazyListElement(this);
+}
 
-    scrollOffset = scrollOffset.clamp(0, itemCount - 1);
+/// Mount element class corresponding to [LazyList].
+class LazyListElement extends Element {
+  /// Caches child elements created for the visible items.
+  List<Element?> childElements = [];
 
-    for (var i = 0; i < area.height; i++) {
-      final index = scrollOffset + i;
-      if (index >= itemCount) break;
+  /// Instantiates the rendering element for the given LazyList.
+  LazyListElement(LazyList super.widget);
 
-      final childWidget = itemBuilder(index);
-      final childArea = Rect(0, i, area.width, 1);
-      final vp = Viewport(buffer, childArea);
-      childWidget.render(vp, Rect(0, 0, area.width, 1));
+  @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void unmount() {
+    for (final el in childElements) {
+      el?.unmount();
+    }
+    childElements.clear();
+    super.unmount();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    final lazy = widget as LazyList;
+    _reconcileChildren(lazy.scrollOffset, childElements.length);
+  }
+
+  void _reconcileChildren(int start, int count) {
+    final lazy = widget as LazyList;
+    final targetCount = min(count, lazy.itemCount - start);
+
+    while (childElements.length > targetCount) {
+      childElements.removeLast()?.unmount();
+    }
+
+    while (childElements.length < targetCount) {
+      childElements.add(null);
+    }
+
+    for (var i = 0; i < targetCount; i++) {
+      final index = start + i;
+      if (index >= lazy.itemCount) break;
+      final childWidget = lazy.itemBuilder(index);
+      final currentChild = childElements[i];
+      if (currentChild != null &&
+          currentChild.widget.runtimeType == childWidget.runtimeType) {
+        currentChild.update(childWidget);
+      } else {
+        currentChild?.unmount();
+        final newChild = childWidget.createElement();
+        newChild.mount(this);
+        childElements[i] = newChild;
+      }
+    }
+  }
+
+  @override
+  void visitChildren(void Function(Element child) visitor) {
+    for (final el in childElements) {
+      if (el != null) visitor(el);
+    }
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final lazy = widget as LazyList;
+    final width = constraints.hasBoundedWidth ? constraints.maxWidth : 80;
+    final height = constraints.hasBoundedHeight
+        ? constraints.maxHeight
+        : lazy.itemCount;
+
+    if (lazy.itemCount > 0) {
+      lazy.scrollOffset = lazy.scrollOffset.clamp(0, lazy.itemCount - 1);
+    } else {
+      lazy.scrollOffset = 0;
+    }
+
+    final visibleCount = min(height, lazy.itemCount - lazy.scrollOffset);
+    _reconcileChildren(lazy.scrollOffset, height);
+
+    for (var i = 0; i < visibleCount; i++) {
+      final el = childElements[i];
+      if (el != null) {
+        el.layout(BoxConstraints.tight(Size(width, 1)));
+      }
+    }
+
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final lazy = widget as LazyList;
+    final limit = min(size.height, lazy.itemCount - lazy.scrollOffset);
+    for (var i = 0; i < limit; i++) {
+      final el = childElements[i];
+      if (el != null) {
+        final childRect = Rect(offset.dx, offset.dy + i, size.width, 1);
+        final vp = Viewport(buffer, childRect);
+        el.paint(vp, Offset.zero);
+      }
     }
   }
 }
@@ -131,70 +231,105 @@ class LazyTable extends Widget {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
+  Element createElement() => LazyTableElement(this);
+}
 
-    final hasHeaders = headers.isNotEmpty;
+/// Mount element class corresponding to [LazyTable].
+class LazyTableElement extends Element {
+  /// Column widths resolved during [performLayout].
+  List<int> resolvedColumnWidths = [];
+
+  /// Instantiates the rendering element for the given LazyTable.
+  LazyTableElement(LazyTable super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final table = widget as LazyTable;
+    final width = constraints.hasBoundedWidth ? constraints.maxWidth : 80;
+    final height = constraints.hasBoundedHeight
+        ? constraints.maxHeight
+        : (table.itemCount + (table.headers.isNotEmpty ? 2 : 0));
+
+    final hasHeaders = table.headers.isNotEmpty;
     final headerRowsCount = hasHeaders ? 2 : 0;
-    final usableHeight = area.height - headerRowsCount;
+    final usableHeight = height - headerRowsCount;
+
+    if (usableHeight > 0) {
+      table.adjustScroll(usableHeight);
+    }
+
+    resolvedColumnWidths = List<int>.generate(table.headers.length, (c) {
+      return c < table.columnWidths.length ? table.columnWidths[c] : 10;
+    });
+
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final table = widget as LazyTable;
+    final w = size.width;
+    final h = size.height;
+    if (w <= 0 || h <= 0) return;
+
+    final hasHeaders = table.headers.isNotEmpty;
+    final headerRowsCount = hasHeaders ? 2 : 0;
+    final usableHeight = h - headerRowsCount;
 
     if (usableHeight <= 0) return;
 
     // 1. Render Headers
     if (hasHeaders) {
       final headerSb = StringBuffer();
-      for (var i = 0; i < headers.length; i++) {
-        final width = i < columnWidths.length ? columnWidths[i] : 10;
-        final text = headers[i];
+      for (var i = 0; i < table.headers.length; i++) {
+        final width = resolvedColumnWidths[i];
+        final text = table.headers[i];
         final chars = text.characters;
         final padded = chars.length >= width
             ? chars.take(width).toString()
             : chars.toString() + (' ' * (width - chars.length));
         headerSb.write(padded);
-        if (i < headers.length - 1) headerSb.write(' ');
+        if (i < table.headers.length - 1) headerSb.write(' ');
       }
       final headerChars = headerSb.toString().characters;
-      final headerStr = headerChars.length >= area.width
-          ? headerChars.take(area.width).toString()
-          : headerChars.toString() + (' ' * (area.width - headerChars.length));
-      buffer.writeString(0, 0, headerStr, headerStyle);
+      final headerStr = headerChars.length >= w
+          ? headerChars.take(w).toString()
+          : headerChars.toString() + (' ' * (w - headerChars.length));
+      buffer.writeString(offset.dx, offset.dy, headerStr, table.headerStyle);
 
       // Render Divider Line
       final dividerChar = '─';
-      final divider = dividerChar * area.width;
-      buffer.writeString(0, 1, divider, borderStyle);
+      final divider = dividerChar * w;
+      buffer.writeString(offset.dx, offset.dy + 1, divider, table.borderStyle);
     }
 
-    // 2. Adjust Scroll
-    adjustScroll(usableHeight);
-
-    // 3. Render Visible Rows
+    // 2. Render Visible Rows
     for (var r = 0; r < usableHeight; r++) {
-      final rowIdx = scrollOffset + r;
-      if (rowIdx >= itemCount) break;
+      final rowIdx = table.scrollOffset + r;
+      if (rowIdx >= table.itemCount) break;
 
-      final rowData = itemBuilder(rowIdx);
-      final isSelected = rowIdx == selectedRowIndex;
-      final currentStyle = isSelected ? selectedRowStyle : rowStyle;
+      final rowData = table.itemBuilder(rowIdx);
+      final isSelected = rowIdx == table.selectedRowIndex;
+      final currentStyle = isSelected ? table.selectedRowStyle : table.rowStyle;
 
       final rowSb = StringBuffer();
-      for (var c = 0; c < headers.length; c++) {
-        final width = c < columnWidths.length ? columnWidths[c] : 10;
+      for (var c = 0; c < table.headers.length; c++) {
+        final width = resolvedColumnWidths[c];
         final cellText = c < rowData.length ? rowData[c] : '';
         final chars = cellText.characters;
         final padded = chars.length >= width
             ? chars.take(width).toString()
             : chars.toString() + (' ' * (width - chars.length));
         rowSb.write(padded);
-        if (c < headers.length - 1) rowSb.write(' ');
+        if (c < table.headers.length - 1) rowSb.write(' ');
       }
 
       final rowChars = rowSb.toString().characters;
-      final targetY = headerRowsCount + r;
+      final targetY = offset.dy + headerRowsCount + r;
 
-      for (var x = 0; x < area.width; x++) {
+      for (var x = 0; x < w; x++) {
         final char = x < rowChars.length ? rowChars.elementAt(x) : ' ';
-        final cell = buffer.getCell(x, targetY);
+        final cell = buffer.getCell(offset.dx + x, targetY);
         if (cell != null) {
           cell.char = char;
           cell.style = currentStyle;

--- a/packages/termui/lib/ui/widgets/left_border.dart
+++ b/packages/termui/lib/ui/widgets/left_border.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import '../buffer.dart';
 import '../layout.dart';
 import '../style.dart';
@@ -30,13 +31,6 @@ class LeftBorder extends Widget {
 
   @override
   Element createElement() => LeftBorderElement(this);
-
-  @override
-  void render(Buffer buffer, Rect area) {
-    // Fallback for direct widget rendering outside of active element tree
-    final rootContext = LeftBorderElement(this)..mount(null);
-    rootContext.render(buffer, area);
-  }
 }
 
 /// The Element corresponding to a [LeftBorder] widget.
@@ -48,23 +42,74 @@ class LeftBorderElement extends Element {
   LeftBorderElement(LeftBorder super.widget);
 
   @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    final borderWidget = widget as LeftBorder;
+    if (childElement != null &&
+        childElement!.widget.runtimeType == borderWidget.child.runtimeType) {
+      childElement!.update(borderWidget.child);
+    } else {
+      childElement?.unmount();
+      childElement = borderWidget.child.createElement();
+      childElement!.mount(this);
+    }
+  }
+
+  @override
   void visitChildren(void Function(Element child) visitor) {
     if (childElement != null) visitor(childElement!);
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Size performLayout(BoxConstraints constraints) {
+    final borderWidget = widget as LeftBorder;
+    final padding = borderWidget.padding;
+    final extraW = 1 + padding.left + padding.right;
+    final extraH = padding.top + padding.bottom;
+
+    if (childElement != null) {
+      final childConstraints = BoxConstraints(
+        minWidth: max(0, constraints.minWidth - extraW),
+        maxWidth: constraints.maxWidth == BoxConstraints.infinity
+            ? BoxConstraints.infinity
+            : max(0, constraints.maxWidth - extraW),
+        minHeight: max(0, constraints.minHeight - extraH),
+        maxHeight: constraints.maxHeight == BoxConstraints.infinity
+            ? BoxConstraints.infinity
+            : max(0, constraints.maxHeight - extraH),
+      );
+      final childSize = childElement!.layout(childConstraints);
+      return constraints.constrain(
+        Size(childSize.width + extraW, childSize.height + extraH),
+      );
+    }
+    return constraints.constrain(Size(extraW, extraH));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
     final borderWidget = widget as LeftBorder;
     final padding = borderWidget.padding;
     final requiredWidth = 1 + padding.left + padding.right;
     final requiredHeight = padding.top + padding.bottom;
-    if (area.width <= requiredWidth || area.height <= requiredHeight) return;
+    if (size.width <= requiredWidth || size.height <= requiredHeight) return;
 
-    final limit = borderWidget.borderHeight ?? area.height;
+    final limit = borderWidget.borderHeight ?? size.height;
     // 1. Draw the vertical line on the left
-    for (var y = 0; y < area.height; y++) {
+    for (var y = 0; y < size.height; y++) {
       final cellChar = y < limit ? borderWidget.char : ' ';
-      final cell = buffer.getCell(area.x, area.y + y);
+      final cell = buffer.getCell(offset.dx, offset.dy + y);
       if (cell != null) {
         cell.char = cellChar;
         cell.style = borderWidget.style;
@@ -72,21 +117,12 @@ class LeftBorderElement extends Element {
     }
 
     // 2. Render the child in the remaining area
-    final childX = area.x + 1 + padding.left;
-    final childWidth = area.width - 1 - padding.left - padding.right;
-    final childY = area.y + padding.top;
-    final childHeight = area.height - padding.top - padding.bottom;
-    final childArea = Rect(childX, childY, childWidth, childHeight);
-
-    if (childElement != null &&
-        childElement!.widget.runtimeType == borderWidget.child.runtimeType) {
-      childElement!.update(borderWidget.child);
-    } else {
-      childElement = borderWidget.child.createElement();
-      childElement!.mount(this);
+    if (childElement != null) {
+      final childOffset = Offset(
+        offset.dx + 1 + padding.left,
+        offset.dy + padding.top,
+      );
+      childElement!.paint(buffer, childOffset);
     }
-
-    final childViewport = Viewport(buffer, childArea);
-    childElement!.render(childViewport, Rect(0, 0, childWidth, childHeight));
   }
 }

--- a/packages/termui/lib/ui/widgets/linear_progress_indicator.dart
+++ b/packages/termui/lib/ui/widgets/linear_progress_indicator.dart
@@ -79,47 +79,75 @@ class LinearProgressIndicator extends Widget {
   ];
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
+  Element createElement() => LinearProgressIndicatorElement(this);
+}
 
-    final clamped = fraction.clamp(0.0, 1.0);
-    final eased = easing(clamped);
-    final progressVal = (eased * area.width).clamp(0.0, area.width.toDouble());
+/// An element that manages the rendering of a [LinearProgressIndicator] widget.
+class LinearProgressIndicatorElement extends Element {
+  /// Creates a [LinearProgressIndicatorElement] for the given [widget].
+  LinearProgressIndicatorElement(LinearProgressIndicator super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final w = constraints.maxWidth == BoxConstraints.infinity
+        ? 20
+        : constraints.maxWidth;
+    return constraints.constrain(Size(w, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final viewport = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
+    final progress = widget as LinearProgressIndicator;
+    if (size.width <= 0 || size.height <= 0) return;
+
+    final clamped = progress.fraction.clamp(0.0, 1.0);
+    final eased = progress.easing(clamped);
+    final progressVal = (eased * size.width).clamp(0.0, size.width.toDouble());
     final filledWidth = progressVal.floor();
 
-    // Determine the percentage text if shown
     String? pctText;
     int? pctStartIdx;
-    if (showPercentage) {
+    if (progress.showPercentage) {
       pctText = '${(eased * 100).toInt().clamp(0, 100)}%';
-      if (pctText.length < area.width - 2) {
-        pctStartIdx = ((area.width - pctText.length) / 2).floor();
+      if (pctText.length < size.width - 2) {
+        pctStartIdx = ((size.width - pctText.length) / 2).floor();
       } else {
         pctText = null;
       }
     }
 
-    final hasGradient = startColor != null && endColor != null;
-    var cellStyle = style;
+    final hasGradient =
+        progress.startColor != null && progress.endColor != null;
+    var cellStyle = progress.style;
 
-    for (var x = 0; x < area.width; x++) {
-      // 1. Calculate style (interpolate color if gradient enabled)
+    for (var x = 0; x < size.width; x++) {
       if (hasGradient) {
-        final t = area.width > 1 ? x / (area.width - 1) : 0.0;
-        final r = (startColor!.r + t * (endColor!.r - startColor!.r)).round();
-        final g = (startColor!.g + t * (endColor!.g - startColor!.g)).round();
-        final b = (startColor!.b + t * (endColor!.b - startColor!.b)).round();
+        final t = size.width > 1 ? x / (size.width - 1) : 0.0;
+        final r =
+            (progress.startColor!.r +
+                    t * (progress.endColor!.r - progress.startColor!.r))
+                .round();
+        final g =
+            (progress.startColor!.g +
+                    t * (progress.endColor!.g - progress.startColor!.g))
+                .round();
+        final b =
+            (progress.startColor!.b +
+                    t * (progress.endColor!.b - progress.startColor!.b))
+                .round();
         cellStyle = Style(
           foreground: Color(r, g, b),
-          background: style.background,
-          modifiers: style.modifiers,
+          background: progress.style.background,
+          modifiers: progress.style.modifiers,
         );
       }
 
-      // 2. Determine character
-      String char = '░'; // background character
+      String char = '░';
 
-      // Check if we are inside the percentage text range
       if (pctText != null &&
           pctStartIdx != null &&
           x >= pctStartIdx &&
@@ -130,10 +158,10 @@ class LinearProgressIndicator extends Widget {
           char = '█';
         } else if (x == filledWidth) {
           final remainder = progressVal - filledWidth;
-          if (smooth) {
+          if (progress.smooth) {
             final idx = (remainder * 8).round() - 1;
             if (idx >= 0 && idx < 8) {
-              char = eighths[idx];
+              char = LinearProgressIndicator.eighths[idx];
             } else if (idx >= 8) {
               char = '█';
             }
@@ -145,7 +173,7 @@ class LinearProgressIndicator extends Widget {
         }
       }
 
-      final cell = buffer.getCell(x, 0);
+      final cell = viewport.getCell(x, 0);
       if (cell != null) {
         cell.char = char;
         cell.style = cellStyle;

--- a/packages/termui/lib/ui/widgets/list_widget.dart
+++ b/packages/termui/lib/ui/widgets/list_widget.dart
@@ -50,22 +50,58 @@ class ListWidget extends Widget {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    adjustScroll(area.height);
+  Element createElement() => ListWidgetElement(this);
+}
 
-    for (var i = 0; i < area.height; i++) {
-      final itemIdx = scrollOffset + i;
-      if (itemIdx >= items.length) break;
+/// Mount element class corresponding to [ListWidget].
+class ListWidgetElement extends Element {
+  /// The indices of the visible items calculated in [performLayout].
+  List<int> visibleIndices = [];
 
-      final isSelected = itemIdx == selectedIndex;
-      final text = items[itemIdx];
-      // Pad line to fit full width in a grapheme-safe way
+  /// Instantiates the rendering element for the given ListWidget.
+  ListWidgetElement(ListWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final listWidget = widget as ListWidget;
+    final width = constraints.hasBoundedWidth ? constraints.maxWidth : 80;
+    final height = constraints.hasBoundedHeight
+        ? constraints.maxHeight
+        : listWidget.items.length;
+
+    listWidget.adjustScroll(height);
+
+    visibleIndices = [];
+    for (var i = 0; i < height; i++) {
+      final itemIdx = listWidget.scrollOffset + i;
+      if (itemIdx >= listWidget.items.length) break;
+      visibleIndices.add(itemIdx);
+    }
+
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final listWidget = widget as ListWidget;
+    final w = size.width;
+
+    for (var i = 0; i < visibleIndices.length; i++) {
+      final itemIdx = visibleIndices[i];
+      final isSelected = itemIdx == listWidget.selectedIndex;
+      final text = listWidget.items[itemIdx];
+
       final chars = text.characters;
-      final padded = chars.length >= area.width
-          ? chars.take(area.width).toString()
-          : chars.toString() + (' ' * (area.width - chars.length));
+      final padded = chars.length >= w
+          ? chars.take(w).toString()
+          : chars.toString() + (' ' * (w - chars.length));
 
-      buffer.writeString(0, i, padded, isSelected ? selectedStyle : itemStyle);
+      buffer.writeString(
+        offset.dx,
+        offset.dy + i,
+        padded,
+        isSelected ? listWidget.selectedStyle : listWidget.itemStyle,
+      );
     }
   }
 }

--- a/packages/termui/lib/ui/widgets/modal_overlay.dart
+++ b/packages/termui/lib/ui/widgets/modal_overlay.dart
@@ -136,31 +136,62 @@ class ModalOverlay extends Window {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (bounds.width <= 0 || bounds.height <= 0) return;
+  Element createElement() => ModalOverlayElement(this);
+}
+
+/// Element class corresponding to [ModalOverlay], managing layout and paint of the modal.
+class ModalOverlayElement extends WindowElement {
+  /// Instantiates the rendering element for the given ModalOverlay.
+  ModalOverlayElement(ModalOverlay super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final modal = widget as ModalOverlay;
+    final width = constraints.hasBoundedWidth
+        ? constraints.maxWidth
+        : modal.bounds.width;
+    final height = constraints.hasBoundedHeight
+        ? constraints.maxHeight
+        : modal.bounds.height;
+
+    if (childElement != null) {
+      final childW = max(0, modal.dialogBounds.width - 2);
+      final childH = max(0, modal.dialogBounds.height - 2);
+      childElement!.layout(BoxConstraints.tight(Size(childW, childH)));
+    }
+
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final modal = widget as ModalOverlay;
+    final w = size.width;
+    final h = size.height;
+    if (w <= 0 || h <= 0) return;
 
     // 1. Check/force focus to modal if it got lost/not set
     bool anyFocused = false;
-    for (final node in modalFocusNodes) {
+    for (final node in modal.modalFocusNodes) {
       if (node.isFocused) {
         anyFocused = true;
         break;
       }
     }
-    if (!anyFocused && modalFocusNodes.isNotEmpty) {
-      modalFocusNodes.first.requestFocus();
+    if (!anyFocused && modal.modalFocusNodes.isNotEmpty) {
+      modal.modalFocusNodes.first.requestFocus();
     }
 
     // 2. Draw the background scrim (dimming the cells beneath the modal)
-    for (var y = 0; y < bounds.height; y++) {
-      for (var x = 0; x < bounds.width; x++) {
-        final cell = buffer.getCell(bounds.x + x, bounds.y + y);
+    for (var y = 0; y < h; y++) {
+      for (var x = 0; x < w; x++) {
+        final cell = buffer.getCell(offset.dx + x, offset.dy + y);
         if (cell != null) {
           final isInsideDialog =
-              x >= dialogBounds.x &&
-              x < dialogBounds.x + dialogBounds.width &&
-              y >= dialogBounds.y &&
-              y < dialogBounds.y + dialogBounds.height;
+              x >= modal.dialogBounds.x &&
+              x < modal.dialogBounds.x + modal.dialogBounds.width &&
+              y >= modal.dialogBounds.y &&
+              y < modal.dialogBounds.y + modal.dialogBounds.height;
           if (!isInsideDialog) {
             cell.style = Style(
               foreground: cell.style.foreground,
@@ -173,9 +204,97 @@ class ModalOverlay extends Window {
     }
 
     // 3. Draw the central dialog box inside dialogBounds
-    final originalBounds = bounds;
-    bounds = dialogBounds;
-    super.render(buffer, area);
-    bounds = originalBounds;
+    final dialogX = offset.dx + modal.dialogBounds.x;
+    final dialogY = offset.dy + modal.dialogBounds.y;
+    final dw = modal.dialogBounds.width;
+    final dh = modal.dialogBounds.height;
+
+    if (dw < 2 || dh < 2) {
+      for (var y = 0; y < dh; y++) {
+        for (var x = 0; x < dw; x++) {
+          final cell = buffer.getCell(dialogX + x, dialogY + y);
+          if (cell != null) {
+            cell.char = ' ';
+            cell.style = modal.borderStyle;
+          }
+        }
+      }
+      return;
+    }
+
+    // Draw top border
+    final topBorder =
+        modal.borderChars[0] +
+        modal.borderChars[1] * (dw - 2) +
+        modal.borderChars[2];
+    buffer.writeString(dialogX, dialogY, topBorder, modal.borderStyle);
+
+    // Overlay title
+    if (modal.title.isNotEmpty) {
+      final titleChars = modal.title.characters;
+      final maxTitleLen = dw - 4;
+      String displayedTitle;
+      if (titleChars.length > maxTitleLen) {
+        final cutLen = dw - 7;
+        if (cutLen > 0) {
+          displayedTitle = ' ${titleChars.take(cutLen).toString()}... ';
+        } else {
+          displayedTitle = '';
+        }
+      } else {
+        displayedTitle = ' ${modal.title} ';
+      }
+
+      if (displayedTitle.isNotEmpty) {
+        final dispChars = displayedTitle.characters;
+        final titleX = max(
+          1,
+          min(dw - 2, ((dw - dispChars.length) / 2).floor()),
+        );
+        buffer.writeString(
+          dialogX + titleX,
+          dialogY,
+          displayedTitle,
+          modal.titleStyle,
+        );
+      }
+    }
+
+    // Side borders
+    for (var y = 1; y < dh - 1; y++) {
+      buffer.writeString(
+        dialogX,
+        dialogY + y,
+        modal.borderChars[3],
+        modal.borderStyle,
+      );
+      buffer.writeString(
+        dialogX + dw - 1,
+        dialogY + y,
+        modal.borderChars[5],
+        modal.borderStyle,
+      );
+    }
+
+    // Bottom border
+    final bottomBorder =
+        modal.borderChars[6] +
+        modal.borderChars[7] * (dw - 2) +
+        modal.borderChars[8];
+    buffer.writeString(
+      dialogX,
+      dialogY + dh - 1,
+      bottomBorder,
+      modal.borderStyle,
+    );
+
+    // Render child content viewport
+    final contentArea = Rect(dialogX + 1, dialogY + 1, dw - 2, dh - 2);
+    final contentViewport = Viewport(buffer, contentArea);
+    contentViewport.fill(Cell(' ', modal.backgroundStyle));
+
+    if (childElement != null) {
+      childElement!.paint(contentViewport, Offset.zero);
+    }
   }
 }

--- a/packages/termui/lib/ui/widgets/number_selector.dart
+++ b/packages/termui/lib/ui/widgets/number_selector.dart
@@ -72,22 +72,50 @@ class NumberSelector extends Widget {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final labelLen = label.characters.length;
-    final displayChars = '$label: < $value >'.characters;
+  Element createElement() => NumberSelectorElement(this);
+}
+
+/// An element that manages the rendering and layout of a [NumberSelector] widget.
+class NumberSelectorElement extends Element {
+  /// Creates a [NumberSelectorElement] for the given [widget].
+  NumberSelectorElement(NumberSelector super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final selector = widget as NumberSelector;
+    final displayChars = '${selector.label}: < ${selector.value} >';
+    final w = displayChars.characters.length;
+    return constraints.constrain(Size(w, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final selector = widget as NumberSelector;
+    final viewport = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
+
+    final labelLen = selector.label.characters.length;
+    final displayChars = '${selector.label}: < ${selector.value} >'.characters;
     final leftArrowIdx = labelLen + 2;
     final rightArrowIdx = displayChars.length - 1;
 
     // Render the label and spacing
-    buffer.writeString(0, 0, '$label: ', style);
+    viewport.writeString(0, 0, '${selector.label}: ', selector.style);
 
     // Render '<' button
-    buffer.writeString(leftArrowIdx, 0, '<', buttonStyle);
+    viewport.writeString(leftArrowIdx, 0, '<', selector.buttonStyle);
 
     // Render value
-    buffer.writeString(leftArrowIdx + 2, 0, '$value', style);
+    viewport.writeString(
+      leftArrowIdx + 2,
+      0,
+      '${selector.value}',
+      selector.style,
+    );
 
     // Render '>' button
-    buffer.writeString(rightArrowIdx, 0, '>', buttonStyle);
+    viewport.writeString(rightArrowIdx, 0, '>', selector.buttonStyle);
   }
 }

--- a/packages/termui/lib/ui/widgets/overlay.dart
+++ b/packages/termui/lib/ui/widgets/overlay.dart
@@ -441,46 +441,7 @@ class _DropdownButtonRenderWidget extends Widget
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final absBounds = getAbsoluteRect(buffer, area);
-    onRender(absBounds);
-
-    final arrow = isOpen ? '▲' : '▼';
-    final displayStyle = focused
-        ? const Style(modifiers: Modifier.reverse)
-        : style;
-
-    if (area.width > 3) {
-      final childViewport = Viewport(
-        buffer,
-        Rect(area.x + 1, area.y, area.width - 4, area.height),
-      );
-      displayWidget.render(
-        childViewport,
-        Rect(0, 0, area.width - 4, area.height),
-      );
-
-      // Apply the displayStyle (reverse-highlighting when focused) to all cells of childViewport
-      for (var y = 0; y < area.height; y++) {
-        for (var x = 0; x < area.width - 4; x++) {
-          final cell = childViewport.getCell(x, y);
-          if (cell != null) {
-            cell.style = cell.style.merge(displayStyle);
-          }
-        }
-      }
-
-      buffer.writeString(area.x, area.y, '[', displayStyle);
-      buffer.writeString(
-        area.x + area.width - 3,
-        area.y,
-        ' $arrow]',
-        displayStyle,
-      );
-    } else {
-      buffer.writeString(area.x, area.y, arrow, displayStyle);
-    }
-  }
+  Element createElement() => _DropdownButtonRenderWidgetElement(this);
 
   @override
   bool handleKeyEvent(term.KeyEvent event) {
@@ -490,6 +451,107 @@ class _DropdownButtonRenderWidget extends Widget
   void handleMouseEvent(MouseEvent event, int localX, int localY) {
     if (event.type == MouseEventType.press) {
       onAction();
+    }
+  }
+}
+
+class _DropdownButtonRenderWidgetElement extends Element {
+  Element? displayWidgetElement;
+
+  _DropdownButtonRenderWidgetElement(_DropdownButtonRenderWidget super.widget);
+
+  @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void unmount() {
+    displayWidgetElement?.unmount();
+    super.unmount();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    final dButton = widget as _DropdownButtonRenderWidget;
+    if (displayWidgetElement != null &&
+        displayWidgetElement!.widget.runtimeType ==
+            dButton.displayWidget.runtimeType) {
+      displayWidgetElement!.update(dButton.displayWidget);
+    } else {
+      displayWidgetElement?.unmount();
+      displayWidgetElement = dButton.displayWidget.createElement();
+      displayWidgetElement!.mount(this);
+    }
+  }
+
+  @override
+  void visitChildren(void Function(Element child) visitor) {
+    if (displayWidgetElement != null) visitor(displayWidgetElement!);
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final width = constraints.hasBoundedWidth ? constraints.maxWidth : 80;
+    final height = constraints.hasBoundedHeight ? constraints.maxHeight : 1;
+
+    if (displayWidgetElement != null && width > 3) {
+      displayWidgetElement!.layout(
+        BoxConstraints.tight(Size(width - 4, height)),
+      );
+    }
+
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final dButton = widget as _DropdownButtonRenderWidget;
+    final w = size.width;
+    final h = size.height;
+
+    final absBounds = getAbsoluteRect(buffer, Rect(offset.dx, offset.dy, w, h));
+    dButton.onRender(absBounds);
+
+    final arrow = dButton.isOpen ? '▲' : '▼';
+    final displayStyle = dButton.focused
+        ? const Style(modifiers: Modifier.reverse)
+        : dButton.style;
+
+    if (w > 3) {
+      final childViewport = Viewport(
+        buffer,
+        Rect(offset.dx + 1, offset.dy, w - 4, h),
+      );
+      if (displayWidgetElement != null) {
+        displayWidgetElement!.paint(childViewport, Offset.zero);
+      }
+
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w - 4; x++) {
+          final cell = childViewport.getCell(x, y);
+          if (cell != null) {
+            cell.style = cell.style.merge(displayStyle);
+          }
+        }
+      }
+
+      buffer.writeString(offset.dx, offset.dy, '[', displayStyle);
+      buffer.writeString(
+        offset.dx + w - 3,
+        offset.dy,
+        ' $arrow]',
+        displayStyle,
+      );
+    } else {
+      buffer.writeString(offset.dx, offset.dy, arrow, displayStyle);
     }
   }
 }
@@ -506,18 +568,81 @@ class _DropdownMenuItemWidget extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final itemStyle = selected ? style : Style.empty;
-    for (var y = 0; y < area.height; y++) {
-      buffer.writeString(area.x, area.y + y, ' ' * area.width, itemStyle);
+  Element createElement() => _DropdownMenuItemWidgetElement(this);
+}
+
+class _DropdownMenuItemWidgetElement extends Element {
+  Element? childElement;
+
+  _DropdownMenuItemWidgetElement(_DropdownMenuItemWidget super.widget);
+
+  @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void unmount() {
+    childElement?.unmount();
+    super.unmount();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    final item = widget as _DropdownMenuItemWidget;
+    if (childElement != null &&
+        childElement!.widget.runtimeType == item.child.runtimeType) {
+      childElement!.update(item.child);
+    } else {
+      childElement?.unmount();
+      childElement = item.child.createElement();
+      childElement!.mount(this);
+    }
+  }
+
+  @override
+  void visitChildren(void Function(Element child) visitor) {
+    if (childElement != null) visitor(childElement!);
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final width = constraints.hasBoundedWidth ? constraints.maxWidth : 80;
+    final height = constraints.hasBoundedHeight ? constraints.maxHeight : 1;
+
+    if (childElement != null) {
+      childElement!.layout(BoxConstraints.tight(Size(width, height)));
     }
 
-    final vp = Viewport(buffer, area);
-    child.render(vp, Rect(0, 0, area.width, area.height));
+    return constraints.constrain(Size(width, height));
+  }
 
-    if (selected) {
-      for (var y = 0; y < area.height; y++) {
-        for (var x = 0; x < area.width; x++) {
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final item = widget as _DropdownMenuItemWidget;
+    final w = size.width;
+    final h = size.height;
+
+    final itemStyle = item.selected ? item.style : Style.empty;
+    for (var y = 0; y < h; y++) {
+      buffer.writeString(offset.dx, offset.dy + y, ' ' * w, itemStyle);
+    }
+
+    final vp = Viewport(buffer, Rect(offset.dx, offset.dy, w, h));
+    if (childElement != null) {
+      childElement!.paint(vp, Offset.zero);
+    }
+
+    if (item.selected) {
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
           final cell = vp.getCell(x, y);
           if (cell != null) {
             cell.style = cell.style.merge(itemStyle);

--- a/packages/termui/lib/ui/widgets/padding.dart
+++ b/packages/termui/lib/ui/widgets/padding.dart
@@ -24,24 +24,6 @@ class Padding extends Widget {
   Element createElement() => PaddingElement(this);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final childWidth = area.width - padding.left - padding.right;
-    final childHeight = area.height - padding.top - padding.bottom;
-
-    if (childWidth <= 0 || childHeight <= 0) return;
-
-    final childArea = Rect(
-      area.x + padding.left,
-      area.y + padding.top,
-      childWidth,
-      childHeight,
-    );
-
-    final childViewport = Viewport(buffer, childArea);
-    child.render(childViewport, Rect(0, 0, childWidth, childHeight));
-  }
-
-  @override
   int getIntrinsicHeight(int width) {
     final childWidth = width - padding.left - padding.right;
     if (childWidth <= 0) return padding.top + padding.bottom;
@@ -53,41 +35,100 @@ class Padding extends Widget {
 class PaddingElement extends Element {
   /// The instantiated element corresponding to the child widget.
   Element? childElement;
+  Offset _childOffset = Offset.zero;
 
   /// Creates an element for the [Padding] widget.
   PaddingElement(Padding super.widget);
 
   @override
-  void visitChildren(void Function(Element child) visitor) {
-    if (childElement != null) visitor(childElement!);
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
     final paddingWidget = widget as Padding;
-    final childWidth =
-        area.width - paddingWidget.padding.left - paddingWidget.padding.right;
-    final childHeight =
-        area.height - paddingWidget.padding.top - paddingWidget.padding.bottom;
-
-    if (childWidth <= 0 || childHeight <= 0) return;
-
-    final childArea = Rect(
-      area.x + paddingWidget.padding.left,
-      area.y + paddingWidget.padding.top,
-      childWidth,
-      childHeight,
-    );
-
     if (childElement != null &&
         childElement!.widget.runtimeType == paddingWidget.child.runtimeType) {
       childElement!.update(paddingWidget.child);
     } else {
+      childElement?.unmount();
       childElement = paddingWidget.child.createElement();
       childElement!.mount(this);
     }
+  }
 
-    final childViewport = Viewport(buffer, childArea);
-    childElement!.render(childViewport, Rect(0, 0, childWidth, childHeight));
+  @override
+  void unmount() {
+    childElement?.unmount();
+    super.unmount();
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final paddingWidget = widget as Padding;
+    final padding = paddingWidget.padding;
+
+    final doubleWidth = padding.left + padding.right;
+    final doubleHeight = padding.top + padding.bottom;
+
+    final childMinWidth = constraints.minWidth - doubleWidth < 0
+        ? 0
+        : constraints.minWidth - doubleWidth;
+    final childMaxWidth = constraints.maxWidth == BoxConstraints.infinity
+        ? BoxConstraints.infinity
+        : (constraints.maxWidth - doubleWidth < 0
+              ? 0
+              : constraints.maxWidth - doubleWidth);
+    final childMinHeight = constraints.minHeight - doubleHeight < 0
+        ? 0
+        : constraints.minHeight - doubleHeight;
+    final childMaxHeight = constraints.maxHeight == BoxConstraints.infinity
+        ? BoxConstraints.infinity
+        : (constraints.maxHeight - doubleHeight < 0
+              ? 0
+              : constraints.maxHeight - doubleHeight);
+
+    final childConstraints = BoxConstraints(
+      minWidth: childMinWidth,
+      maxWidth: childMaxWidth,
+      minHeight: childMinHeight,
+      maxHeight: childMaxHeight,
+    );
+
+    _childOffset = Offset(padding.left, padding.top);
+
+    if (childElement != null) {
+      final childSize = childElement!.layout(childConstraints);
+      return Size(
+        childSize.width + doubleWidth,
+        childSize.height + doubleHeight,
+      );
+    }
+
+    return Size(doubleWidth, doubleHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final paddingWidget = widget as Padding;
+    final padding = paddingWidget.padding;
+    final doubleWidth = padding.left + padding.right;
+    final doubleHeight = padding.top + padding.bottom;
+    if (size.width > doubleWidth && size.height > doubleHeight) {
+      childElement?.paint(buffer, offset + _childOffset);
+    }
+  }
+
+  @override
+  void visitChildren(void Function(Element child) visitor) {
+    if (childElement != null) visitor(childElement!);
   }
 }

--- a/packages/termui/lib/ui/widgets/paginator.dart
+++ b/packages/termui/lib/ui/widgets/paginator.dart
@@ -70,29 +70,71 @@ class Paginator extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (totalPages <= 0 || area.width <= 0 || area.height <= 0) return;
+  Element createElement() => PaginatorElement(this);
+}
 
-    final current = currentPage.clamp(0, totalPages - 1);
+/// An element that manages the rendering and layout of a [Paginator] widget.
+class PaginatorElement extends Element {
+  /// Creates a [PaginatorElement] for the given [widget].
+  PaginatorElement(Paginator super.widget);
 
-    final dotChars = activeDot.characters;
-    final inactiveDotChars = inactiveDot.characters;
-    final separatorChars = separator.characters;
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final paginator = widget as Paginator;
+    if (paginator.totalPages <= 0) return constraints.constrain(Size.zero);
+
+    final dotChars = paginator.activeDot.characters;
+    final inactiveDotChars = paginator.inactiveDot.characters;
+    final separatorChars = paginator.separator.characters;
+
+    var w = 0;
+    for (var i = 0; i < paginator.totalPages; i++) {
+      final isCurrent = i == paginator.currentPage;
+      w += isCurrent ? dotChars.length : inactiveDotChars.length;
+      if (i < paginator.totalPages - 1) {
+        w += separatorChars.length;
+      }
+    }
+    return constraints.constrain(Size(w, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final viewport = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
+    final paginator = widget as Paginator;
+    if (paginator.totalPages <= 0 || size.width <= 0 || size.height <= 0) {
+      return;
+    }
+
+    final current = paginator.currentPage.clamp(0, paginator.totalPages - 1);
+    final dotChars = paginator.activeDot.characters;
+    final inactiveDotChars = paginator.inactiveDot.characters;
+    final separatorChars = paginator.separator.characters;
 
     var currentX = 0;
-    for (var i = 0; i < totalPages; i++) {
+    for (var i = 0; i < paginator.totalPages; i++) {
       final isCurrent = i == current;
-      final dot = isCurrent ? activeDot : inactiveDot;
+      final dot = isCurrent ? paginator.activeDot : paginator.inactiveDot;
       final dotLen = isCurrent ? dotChars.length : inactiveDotChars.length;
-      final dotStyle = isCurrent ? activeStyle : inactiveStyle;
+      final dotStyle = isCurrent
+          ? paginator.activeStyle
+          : paginator.inactiveStyle;
 
-      if (currentX + dotLen > area.width) break;
-      buffer.writeString(currentX, 0, dot, dotStyle);
+      if (currentX + dotLen > size.width) break;
+      viewport.writeString(currentX, 0, dot, dotStyle);
       currentX += dotLen;
 
-      if (i < totalPages - 1) {
-        if (currentX + separatorChars.length > area.width) break;
-        buffer.writeString(currentX, 0, separator, separatorStyle);
+      if (i < paginator.totalPages - 1) {
+        if (currentX + separatorChars.length > size.width) break;
+        viewport.writeString(
+          currentX,
+          0,
+          paginator.separator,
+          paginator.separatorStyle,
+        );
         currentX += separatorChars.length;
       }
     }

--- a/packages/termui/lib/ui/widgets/prompt_runner.dart
+++ b/packages/termui/lib/ui/widgets/prompt_runner.dart
@@ -116,7 +116,10 @@ class PromptRunner<T> {
 
   /// Default exit conditions mapping.
   static const Map<PromptExitTrigger, PromptExitAction> defaultExitConditions =
-      {PromptExitTrigger.controlC: PromptExitAction.abort};
+      {
+        PromptExitTrigger.controlC: PromptExitAction.abort,
+        PromptExitTrigger.enter: PromptExitAction.complete,
+      };
 
   Completer<T?>? _completer;
   Element? _rootElement;
@@ -257,7 +260,8 @@ class PromptRunner<T> {
 
       buffer.clear();
       // Render the rebuilt element tree on our double buffer canvas.
-      rootElement.render(buffer, Rect(0, 0, width, computedHeight));
+      rootElement.layout(BoxConstraints.tight(Size(width, computedHeight)));
+      rootElement.paint(buffer, Offset.zero);
 
       final sb = StringBuffer();
       renderer.render(buffer, sb);
@@ -394,7 +398,8 @@ extension PrintWidgetExtension on term.Terminal {
     final buffer = Buffer.blank(width, height);
     final element = widget.createElement();
     element.mount(null);
-    element.render(buffer, Rect(0, 0, width, height));
+    element.layout(BoxConstraints.tight(Size(width, height)));
+    element.paint(buffer, Offset.zero);
     element.unmount();
 
     final renderer = Renderer(width, height, mode: RenderingMode.inline);

--- a/packages/termui/lib/ui/widgets/rich_text.dart
+++ b/packages/termui/lib/ui/widgets/rich_text.dart
@@ -168,40 +168,7 @@ class RichText extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
-
-    final allStyledChars = <StyledChar>[];
-    text.buildStyledChars(allStyledChars, Style.empty);
-
-    final lines = wrap
-        ? _wrapStyledChars(allStyledChars, area.width)
-        : _clipStyledChars(allStyledChars, area.width);
-
-    final limit = maxLines != null ? min(maxLines!, area.height) : area.height;
-    for (var y = 0; y < lines.length; y++) {
-      if (y >= limit) break;
-      final line = lines[y];
-
-      // Compute horizontal alignments
-      final lineLen = line.length;
-      var startX = 0;
-      if (textAlign == TextAlign.right) {
-        startX = max(0, area.width - lineLen);
-      } else if (textAlign == TextAlign.center) {
-        startX = max(0, (area.width - lineLen) ~/ 2);
-      }
-
-      for (var x = 0; x < line.length; x++) {
-        if (startX + x >= area.width) break;
-        final cell = buffer.getCell(startX + x, y);
-        if (cell != null) {
-          cell.char = line[x].char;
-          cell.style = line[x].style;
-        }
-      }
-    }
-  }
+  Element createElement() => RichTextElement(this);
 
   List<List<StyledChar>> _clipStyledChars(
     List<StyledChar> chars,
@@ -329,5 +296,75 @@ class RichText extends Widget {
     }
 
     return lines;
+  }
+}
+
+/// An element that manages a [RichText] widget.
+class RichTextElement extends Element {
+  List<List<StyledChar>> _cachedLines = [];
+
+  /// Creates a rich text element for a [RichText] widget.
+  RichTextElement(RichText super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final richTextWidget = widget as RichText;
+    final width = constraints.maxWidth == BoxConstraints.infinity
+        ? 999999
+        : constraints.maxWidth;
+
+    final allStyledChars = <StyledChar>[];
+    richTextWidget.text.buildStyledChars(allStyledChars, Style.empty);
+
+    _cachedLines = richTextWidget.wrap
+        ? richTextWidget._wrapStyledChars(allStyledChars, width)
+        : richTextWidget._clipStyledChars(allStyledChars, width);
+
+    final limit = richTextWidget.maxLines != null
+        ? min(richTextWidget.maxLines!, _cachedLines.length)
+        : _cachedLines.length;
+
+    var measuredWidth = 0;
+    for (var i = 0; i < limit; i++) {
+      final lineLen = _cachedLines[i].length;
+      if (lineLen > measuredWidth) {
+        measuredWidth = lineLen;
+      }
+    }
+
+    final height = limit;
+    return constraints.constrain(Size(measuredWidth, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final richTextWidget = widget as RichText;
+    final area = Rect(offset.dx, offset.dy, size.width, size.height);
+
+    final limit = richTextWidget.maxLines != null
+        ? min(richTextWidget.maxLines!, area.height)
+        : area.height;
+    for (var y = 0; y < _cachedLines.length; y++) {
+      if (y >= limit) break;
+      final line = _cachedLines[y];
+
+      // Compute horizontal alignments
+      final lineLen = line.length;
+      var startX = 0;
+      if (richTextWidget.textAlign == TextAlign.right) {
+        startX = max(0, area.width - lineLen);
+      } else if (richTextWidget.textAlign == TextAlign.center) {
+        startX = max(0, (area.width - lineLen) ~/ 2);
+      }
+
+      for (var x = 0; x < line.length; x++) {
+        if (startX + x >= area.width) break;
+        final cell = buffer.getCell(area.x + startX + x, area.y + y);
+        if (cell != null) {
+          cell.char = line[x].char;
+          cell.style = line[x].style;
+        }
+      }
+    }
   }
 }

--- a/packages/termui/lib/ui/widgets/scroll_bar.dart
+++ b/packages/termui/lib/ui/widgets/scroll_bar.dart
@@ -99,56 +99,7 @@ class ScrollBar extends Widget {
   Rect? _lastArea;
 
   @override
-  void render(Buffer buffer, Rect area) {
-    _lastArea = area;
-    if (area.width <= 0 || area.height <= 0) return;
-
-    final trackHeight = direction == LayoutDirection.vertical
-        ? area.height
-        : area.width;
-
-    final total = _totalExtent;
-    final view = _viewportExtent;
-    if (total <= 0) return;
-
-    // 1. Calculate thumb size
-    final double ratio = (view / total).clamp(0.0, 1.0);
-    final int thumbHeight = (ratio * trackHeight).round().clamp(1, trackHeight);
-
-    // 2. Calculate thumb position
-    final int maxScrollOffset = total - view;
-    int thumbPos = 0;
-    if (maxScrollOffset > 0) {
-      final double scrollRatio = (_scrollOffset / maxScrollOffset).clamp(
-        0.0,
-        1.0,
-      );
-      thumbPos = (scrollRatio * (trackHeight - thumbHeight)).round().clamp(
-        0,
-        trackHeight - thumbHeight,
-      );
-    }
-
-    if (direction == LayoutDirection.vertical) {
-      for (var y = 0; y < trackHeight; y++) {
-        final isThumb = y >= thumbPos && y < thumbPos + thumbHeight;
-        final cell = buffer.getCell(0, y);
-        if (cell != null) {
-          cell.char = isThumb ? thumbChar : trackChar;
-          cell.style = isThumb ? thumbStyle : trackStyle;
-        }
-      }
-    } else {
-      for (var x = 0; x < trackHeight; x++) {
-        final isThumb = x >= thumbPos && x < thumbPos + thumbHeight;
-        final cell = buffer.getCell(x, 0);
-        if (cell != null) {
-          cell.char = isThumb ? thumbChar : trackChar;
-          cell.style = isThumb ? thumbStyle : trackStyle;
-        }
-      }
-    }
-  }
+  Element createElement() => ScrollBarElement(this);
 
   /// Handles track clicks or dragging of the thumb to update the scroll offset.
   void handleMouseEvent(MouseEvent event, int localX, int localY) {
@@ -171,5 +122,88 @@ class ScrollBar extends Widget {
       maxScrollOffset > 0 ? maxScrollOffset : 0,
     );
     _updateScrollOffset(newOffset);
+  }
+}
+
+/// Mount element class corresponding to [ScrollBar].
+class ScrollBarElement extends Element {
+  /// Proportional height of the thumb indicator calculated during layout.
+  int thumbHeight = 0;
+
+  /// Index position of the thumb indicator calculated during layout.
+  int thumbPos = 0;
+
+  /// Physical track span calculated during layout.
+  int trackHeight = 0;
+
+  /// Instantiates the rendering element for the given ScrollBar.
+  ScrollBarElement(ScrollBar super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final sb = widget as ScrollBar;
+    final width = constraints.hasBoundedWidth
+        ? constraints.maxWidth
+        : (sb.direction == LayoutDirection.vertical ? 1 : 80);
+    final height = constraints.hasBoundedHeight
+        ? constraints.maxHeight
+        : (sb.direction == LayoutDirection.vertical ? 80 : 1);
+
+    trackHeight = sb.direction == LayoutDirection.vertical ? height : width;
+
+    final total = sb._totalExtent;
+    final view = sb._viewportExtent;
+    if (total <= 0) {
+      thumbHeight = 0;
+      thumbPos = 0;
+    } else {
+      final double ratio = (view / total).clamp(0.0, 1.0);
+      thumbHeight = (ratio * trackHeight).round().clamp(1, trackHeight);
+
+      final int maxScrollOffset = total - view;
+      thumbPos = 0;
+      if (maxScrollOffset > 0) {
+        final double scrollRatio = (sb._scrollOffset / maxScrollOffset).clamp(
+          0.0,
+          1.0,
+        );
+        thumbPos = (scrollRatio * (trackHeight - thumbHeight)).round().clamp(
+          0,
+          trackHeight - thumbHeight,
+        );
+      }
+    }
+
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final sb = widget as ScrollBar;
+    sb._lastArea = Rect(offset.dx, offset.dy, size.width, size.height);
+
+    if (size.width <= 0 || size.height <= 0) return;
+    final total = sb._totalExtent;
+    if (total <= 0) return;
+
+    if (sb.direction == LayoutDirection.vertical) {
+      for (var y = 0; y < trackHeight; y++) {
+        final isThumb = y >= thumbPos && y < thumbPos + thumbHeight;
+        final cell = buffer.getCell(offset.dx, offset.dy + y);
+        if (cell != null) {
+          cell.char = isThumb ? sb.thumbChar : sb.trackChar;
+          cell.style = isThumb ? sb.thumbStyle : sb.trackStyle;
+        }
+      }
+    } else {
+      for (var x = 0; x < trackHeight; x++) {
+        final isThumb = x >= thumbPos && x < thumbPos + thumbHeight;
+        final cell = buffer.getCell(offset.dx + x, offset.dy);
+        if (cell != null) {
+          cell.char = isThumb ? sb.thumbChar : sb.trackChar;
+          cell.style = isThumb ? sb.thumbStyle : sb.trackStyle;
+        }
+      }
+    }
   }
 }

--- a/packages/termui/lib/ui/widgets/seven_segment_display.dart
+++ b/packages/termui/lib/ui/widgets/seven_segment_display.dart
@@ -111,23 +111,46 @@ class SevenSegmentDisplay extends Widget {
   };
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height < 5) return;
+  Element createElement() => SevenSegmentDisplayElement(this);
+}
 
-    final activeSt = Style(foreground: activeColor);
-    final inactiveSt = Style(foreground: inactiveColor);
+/// An element that manages the rendering and layout of a [SevenSegmentDisplay] widget.
+class SevenSegmentDisplayElement extends Element {
+  /// Creates a [SevenSegmentDisplayElement] for the given [widget].
+  SevenSegmentDisplayElement(SevenSegmentDisplay super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final display = widget as SevenSegmentDisplay;
+    final count = display.value.length;
+    final w = count > 0 ? (count * 6 - 1) : 0;
+    return constraints.constrain(Size(w, 5));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final viewport = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
+    final display = widget as SevenSegmentDisplay;
+    if (size.width <= 0 || size.height < 5) return;
+
+    final activeSt = Style(foreground: display.activeColor);
+    final inactiveSt = Style(foreground: display.inactiveColor);
 
     int offsetX = 0;
-    for (int i = 0; i < value.length; i++) {
-      final char = value[i];
-      final matrix = _digits[char] ?? _digits[' '];
+    for (int i = 0; i < display.value.length; i++) {
+      final char = display.value[i];
+      final matrix =
+          SevenSegmentDisplay._digits[char] ?? SevenSegmentDisplay._digits[' '];
 
       if (matrix != null) {
         for (int y = 0; y < 5; y++) {
           for (int x = 0; x < 5; x++) {
-            if (offsetX + x < area.width && y < area.height) {
+            if (offsetX + x < size.width && y < size.height) {
               final active = matrix[y][x] == 1;
-              buffer.writeString(
+              viewport.writeString(
                 offsetX + x,
                 y,
                 '█',

--- a/packages/termui/lib/ui/widgets/single_child_scroll_view.dart
+++ b/packages/termui/lib/ui/widgets/single_child_scroll_view.dart
@@ -110,13 +110,6 @@ class _ScrollViewRenderProxy extends Widget {
 
   @override
   Element createElement() => _ScrollViewRenderProxyElement(this);
-
-  @override
-  void render(Buffer buffer, Rect area) {
-    // Fallback for direct widget rendering outside of active element tree
-    final rootContext = _ScrollViewRenderProxyElement(this)..mount(null);
-    rootContext.render(buffer, area);
-  }
 }
 
 class _ScrollViewRenderProxyElement extends Element {
@@ -125,81 +118,131 @@ class _ScrollViewRenderProxyElement extends Element {
   _ScrollViewRenderProxyElement(_ScrollViewRenderProxy super.widget);
 
   @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void unmount() {
+    childElement?.unmount();
+    super.unmount();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    final proxyWidget = widget as _ScrollViewRenderProxy;
+    if (childElement != null &&
+        childElement!.widget.runtimeType == proxyWidget.child.runtimeType) {
+      childElement!.update(proxyWidget.child);
+    } else {
+      childElement?.unmount();
+      childElement = proxyWidget.child.createElement();
+      childElement!.mount(this);
+    }
+  }
+
+  @override
   void visitChildren(void Function(Element child) visitor) {
     if (childElement != null) visitor(childElement!);
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Size performLayout(BoxConstraints constraints) {
     final proxyWidget = widget as _ScrollViewRenderProxy;
-    if (area.width <= 0 || area.height <= 0) return;
+    final width = constraints.hasBoundedWidth ? constraints.maxWidth : 80;
+    final height = constraints.hasBoundedHeight ? constraints.maxHeight : 80;
 
     final extent = proxyWidget.scrollDirection == LayoutDirection.vertical
-        ? area.height
-        : area.width;
+        ? height
+        : width;
     proxyWidget.controller.viewportExtent = extent;
 
-    final scrollOffset = proxyWidget.controller.scrollOffset;
     final int childWidth =
         proxyWidget.scrollDirection == LayoutDirection.vertical
-        ? area.width
+        ? width
         : proxyWidget.controller.totalExtent;
     final int childHeight =
         proxyWidget.scrollDirection == LayoutDirection.vertical
         ? proxyWidget.controller.totalExtent
-        : area.height;
+        : height;
 
-    if (childWidth <= 0 || childHeight <= 0) return;
-
-    if (childElement != null &&
-        childElement!.widget.runtimeType == proxyWidget.child.runtimeType) {
-      childElement!.update(proxyWidget.child);
-    } else {
-      childElement = proxyWidget.child.createElement();
-      childElement!.mount(this);
+    if (childElement != null && childWidth > 0 && childHeight > 0) {
+      final childConstraints = BoxConstraints.tight(
+        Size(childWidth, childHeight),
+      );
+      childElement!.layout(childConstraints);
     }
 
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final proxyWidget = widget as _ScrollViewRenderProxy;
+    final w = size.width;
+    final h = size.height;
+    if (w <= 0 || h <= 0) return;
+
+    final scrollOffset = proxyWidget.controller.scrollOffset;
+    final int childWidth =
+        proxyWidget.scrollDirection == LayoutDirection.vertical
+        ? w
+        : proxyWidget.controller.totalExtent;
+    final int childHeight =
+        proxyWidget.scrollDirection == LayoutDirection.vertical
+        ? proxyWidget.controller.totalExtent
+        : h;
+
+    if (childWidth <= 0 || childHeight <= 0 || childElement == null) return;
+
     final virtualBuffer = Buffer.blank(childWidth, childHeight);
-    childElement!.render(virtualBuffer, Rect(0, 0, childWidth, childHeight));
+    childElement!.paint(virtualBuffer, Offset.zero);
 
     if (proxyWidget.scrollDirection == LayoutDirection.vertical) {
-      for (var y = 0; y < area.height; y++) {
+      for (var y = 0; y < h; y++) {
         final srcY = scrollOffset + y;
         if (srcY >= childHeight) break;
-        for (var x = 0; x < area.width; x++) {
+        for (var x = 0; x < w; x++) {
           final cell = virtualBuffer.getCell(x, srcY);
           if (cell != null) {
-            final targetCell = buffer.getCell(area.x + x, area.y + y);
+            final targetCell = buffer.getCell(offset.dx + x, offset.dy + y);
             if (targetCell != null) {
               final mergedStyle = targetCell.style.merge(cell.style);
               buffer.setCell(
-                area.x + x,
-                area.y + y,
+                offset.dx + x,
+                offset.dy + y,
                 Cell(cell.char, mergedStyle),
               );
             } else {
-              buffer.setCell(area.x + x, area.y + y, cell);
+              buffer.setCell(offset.dx + x, offset.dy + y, cell);
             }
           }
         }
       }
     } else {
-      for (var y = 0; y < area.height; y++) {
-        for (var x = 0; x < area.width; x++) {
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
           final srcX = scrollOffset + x;
           if (srcX >= childWidth) break;
           final cell = virtualBuffer.getCell(srcX, y);
           if (cell != null) {
-            final targetCell = buffer.getCell(area.x + x, area.y + y);
+            final targetCell = buffer.getCell(offset.dx + x, offset.dy + y);
             if (targetCell != null) {
               final mergedStyle = targetCell.style.merge(cell.style);
               buffer.setCell(
-                area.x + x,
-                area.y + y,
+                offset.dx + x,
+                offset.dy + y,
                 Cell(cell.char, mergedStyle),
               );
             } else {
-              buffer.setCell(area.x + x, area.y + y, cell);
+              buffer.setCell(offset.dx + x, offset.dy + y, cell);
             }
           }
         }

--- a/packages/termui/lib/ui/widgets/slider.dart
+++ b/packages/termui/lib/ui/widgets/slider.dart
@@ -202,35 +202,78 @@ class _SliderRenderWidget extends Widget {
   const _SliderRenderWidget({required this.widget, required this.focused});
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final percent = ((widget.value - widget.min) / (widget.max - widget.min))
-        .clamp(0.0, 1.0);
+  Element createElement() => _SliderElement(this);
+}
 
-    if (widget.axis == SliderAxis.horizontal) {
-      final trackLength = area.width;
+class _SliderElement extends Element {
+  _SliderElement(_SliderRenderWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final wWidget = widget as _SliderRenderWidget;
+    final w = wWidget.widget.axis == SliderAxis.horizontal
+        ? (constraints.maxWidth == BoxConstraints.infinity
+              ? 20
+              : constraints.maxWidth)
+        : 1;
+    final h = wWidget.widget.axis == SliderAxis.horizontal
+        ? 1
+        : (constraints.maxHeight == BoxConstraints.infinity
+              ? 10
+              : constraints.maxHeight);
+    return constraints.constrain(Size(w, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final viewport = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
+    final wWidget = widget as _SliderRenderWidget;
+    final percent =
+        ((wWidget.widget.value - wWidget.widget.min) /
+                (wWidget.widget.max - wWidget.widget.min))
+            .clamp(0.0, 1.0);
+
+    if (wWidget.widget.axis == SliderAxis.horizontal) {
+      final trackLength = size.width;
       if (trackLength <= 0) return;
       final thumbPos = (percent * (trackLength - 1)).round();
-      final tc = widget.trackChar == '─' ? '─' : widget.trackChar;
+      final tc = wWidget.widget.trackChar == '─'
+          ? '─'
+          : wWidget.widget.trackChar;
 
       for (int i = 0; i < trackLength; i++) {
         if (i == thumbPos) {
-          buffer.writeString(i, 0, widget.thumbChar, widget.thumbStyle);
+          viewport.writeString(
+            i,
+            0,
+            wWidget.widget.thumbChar,
+            wWidget.widget.thumbStyle,
+          );
         } else {
-          buffer.writeString(i, 0, tc, widget.trackStyle);
+          viewport.writeString(i, 0, tc, wWidget.widget.trackStyle);
         }
       }
     } else {
-      final trackLength = area.height;
+      final trackLength = size.height;
       if (trackLength <= 0) return;
-      // In terminal, Y=0 is top. For vertical sliders, top is max.
       final thumbPos = trackLength - 1 - (percent * (trackLength - 1)).round();
-      final tc = widget.trackChar == '─' ? '│' : widget.trackChar;
+      final tc = wWidget.widget.trackChar == '─'
+          ? '│'
+          : wWidget.widget.trackChar;
 
       for (int i = 0; i < trackLength; i++) {
         if (i == thumbPos) {
-          buffer.writeString(0, i, widget.thumbChar, widget.thumbStyle);
+          viewport.writeString(
+            0,
+            i,
+            wWidget.widget.thumbChar,
+            wWidget.widget.thumbStyle,
+          );
         } else {
-          buffer.writeString(0, i, tc, widget.trackStyle);
+          viewport.writeString(0, i, tc, wWidget.widget.trackStyle);
         }
       }
     }

--- a/packages/termui/lib/ui/widgets/spinner.dart
+++ b/packages/termui/lib/ui/widgets/spinner.dart
@@ -131,8 +131,27 @@ class Spinner extends Widget implements Animatable {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
-    buffer.writeString(0, 0, currentFrame, style);
+  Element createElement() => SpinnerElement(this);
+}
+
+/// An element that manages the rendering and layout of a [Spinner] widget.
+class SpinnerElement extends Element {
+  /// Creates a [SpinnerElement] for the given [widget].
+  SpinnerElement(Spinner super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return constraints.constrain(const Size(1, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final spinner = widget as Spinner;
+    buffer.writeString(
+      offset.dx,
+      offset.dy,
+      spinner.currentFrame,
+      spinner.style,
+    );
   }
 }

--- a/packages/termui/lib/ui/widgets/split_pane.dart
+++ b/packages/termui/lib/ui/widgets/split_pane.dart
@@ -76,6 +76,10 @@ class SplitPane extends Widget {
   });
 
   Rect? _lastArea;
+
+  /// The bounds of the split pane in the last paint pass.
+  Rect? get lastArea => _lastArea;
+
   int _dividerX = 0;
   bool _isDragging = false;
   int? _origMin1;
@@ -85,6 +89,9 @@ class SplitPane extends Widget {
 
   /// Gets the current divider position.
   int get dividerPosition => _dividerX;
+
+  /// Whether the divider is currently being dragged.
+  bool get isDragging => _isDragging;
 
   void _initLimits() {
     if (_origMin1 != null) return;
@@ -101,89 +108,168 @@ class SplitPane extends Widget {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    _lastArea = area;
-    final w = area.width;
-    final h = area.height;
-    if (w <= 0 || h <= 0) return;
+  Element createElement() => SplitPaneElement(this);
+}
 
-    _initLimits();
-    final totalSize = direction == LayoutDirection.horizontal ? w : h;
+/// An element that manages the layout and rendering of a [SplitPane] widget.
+class SplitPaneElement extends Element {
+  /// The element for the first pane child widget.
+  Element? childElement1;
 
-    // 1. Calculate raw divider position based on constraints
+  /// The element for the second pane child widget.
+  Element? childElement2;
+
+  /// Creates a [SplitPaneElement] for the given [widget].
+  SplitPaneElement(SplitPane super.widget);
+
+  @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    final split = widget as SplitPane;
+    if (childElement1 != null &&
+        childElement1!.widget.runtimeType == split.child1.runtimeType) {
+      childElement1!.update(split.child1);
+    } else {
+      childElement1?.unmount();
+      childElement1 = split.child1.createElement();
+      childElement1!.mount(this);
+    }
+
+    if (childElement2 != null &&
+        childElement2!.widget.runtimeType == split.child2.runtimeType) {
+      childElement2!.update(split.child2);
+    } else {
+      childElement2?.unmount();
+      childElement2 = split.child2.createElement();
+      childElement2!.mount(this);
+    }
+  }
+
+  @override
+  void visitChildren(void Function(Element child) visitor) {
+    if (childElement1 != null) visitor(childElement1!);
+    if (childElement2 != null) visitor(childElement2!);
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final split = widget as SplitPane;
+    final w = constraints.maxWidth == BoxConstraints.infinity
+        ? 20
+        : constraints.maxWidth;
+    final h = constraints.maxHeight == BoxConstraints.infinity
+        ? 10
+        : constraints.maxHeight;
+
+    split._initLimits();
+    final totalSize = split.direction == LayoutDirection.horizontal ? w : h;
+
     int dividerPos = _calculateDividerPos(totalSize);
 
-    // 2. Solve min/max limits
-    int minW1 = _origMin1 ?? 0;
-    int maxW1 = _origMax1 ?? (totalSize - 1);
-    if (_origMin2 != null) {
-      maxW1 = min(maxW1, totalSize - _origMin2! - 1);
+    int minW1 = split._origMin1 ?? 0;
+    int maxW1 = split._origMax1 ?? (totalSize - 1);
+    if (split._origMin2 != null) {
+      maxW1 = min(maxW1, totalSize - split._origMin2! - 1);
     }
-    if (_origMax2 != null) {
-      minW1 = max(minW1, totalSize - _origMax2! - 1);
+    if (split._origMax2 != null) {
+      minW1 = max(minW1, totalSize - split._origMax2! - 1);
     }
     minW1 = minW1.clamp(0, totalSize - 1);
     maxW1 = maxW1.clamp(0, totalSize - 1);
     if (minW1 > maxW1) minW1 = maxW1;
 
     dividerPos = dividerPos.clamp(minW1, maxW1);
-    _dividerX = dividerPos;
+    split._dividerX = dividerPos;
 
-    if (direction == LayoutDirection.horizontal) {
-      // Render child1
-      final child1Area = Rect(area.x, area.y, dividerPos, h);
-      if (dividerPos > 0) {
-        final vp1 = Viewport(buffer, child1Area);
-        child1.render(vp1, Rect(0, 0, dividerPos, h));
+    if (split.direction == LayoutDirection.horizontal) {
+      if (dividerPos > 0 && childElement1 != null) {
+        childElement1!.layout(BoxConstraints.tight(Size(dividerPos, h)));
       }
-
-      // Render Divider
-      for (var y = 0; y < h; y++) {
-        final cell = buffer.getCell(area.x + dividerPos, area.y + y);
-        if (cell != null) {
-          cell.char = dividerChar;
-          cell.style = dividerStyle;
-        }
-      }
-
-      // Render child2
       final child2Width = w - dividerPos - 1;
-      final child2Area = Rect(area.x + dividerPos + 1, area.y, child2Width, h);
-      if (child2Width > 0) {
-        final vp2 = Viewport(buffer, child2Area);
-        child2.render(vp2, Rect(0, 0, child2Width, h));
+      if (child2Width > 0 && childElement2 != null) {
+        childElement2!.layout(BoxConstraints.tight(Size(child2Width, h)));
       }
     } else {
-      // Vertical
-      // Render child1
-      final child1Area = Rect(area.x, area.y, w, dividerPos);
-      if (dividerPos > 0) {
-        final vp1 = Viewport(buffer, child1Area);
-        child1.render(vp1, Rect(0, 0, w, dividerPos));
+      if (dividerPos > 0 && childElement1 != null) {
+        childElement1!.layout(BoxConstraints.tight(Size(w, dividerPos)));
+      }
+      final child2Height = h - dividerPos - 1;
+      if (child2Height > 0 && childElement2 != null) {
+        childElement2!.layout(BoxConstraints.tight(Size(w, child2Height)));
+      }
+    }
+
+    return constraints.constrain(Size(w, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final split = widget as SplitPane;
+    split._lastArea = Rect(offset.dx, offset.dy, size.width, size.height);
+    final w = size.width;
+    final h = size.height;
+    if (w <= 0 || h <= 0) return;
+
+    final dividerPos = split._dividerX;
+
+    if (split.direction == LayoutDirection.horizontal) {
+      if (dividerPos > 0 && childElement1 != null) {
+        childElement1!.paint(buffer, offset);
       }
 
-      // Render Divider
-      for (var x = 0; x < w; x++) {
-        final cell = buffer.getCell(area.x + x, area.y + dividerPos);
+      for (var y = 0; y < h; y++) {
+        final cell = buffer.getCell(offset.dx + dividerPos, offset.dy + y);
         if (cell != null) {
-          cell.char = dividerChar;
-          cell.style = dividerStyle;
+          cell.char = split.dividerChar;
+          cell.style = split.dividerStyle;
         }
       }
 
-      // Render child2
+      final child2Width = w - dividerPos - 1;
+      if (child2Width > 0 && childElement2 != null) {
+        childElement2!.paint(
+          buffer,
+          Offset(offset.dx + dividerPos + 1, offset.dy),
+        );
+      }
+    } else {
+      if (dividerPos > 0 && childElement1 != null) {
+        childElement1!.paint(buffer, offset);
+      }
+
+      for (var x = 0; x < w; x++) {
+        final cell = buffer.getCell(offset.dx + x, offset.dy + dividerPos);
+        if (cell != null) {
+          cell.char = split.dividerChar;
+          cell.style = split.dividerStyle;
+        }
+      }
+
       final child2Height = h - dividerPos - 1;
-      final child2Area = Rect(area.x, area.y + dividerPos + 1, w, child2Height);
-      if (child2Height > 0) {
-        final vp2 = Viewport(buffer, child2Area);
-        child2.render(vp2, Rect(0, 0, w, child2Height));
+      if (child2Height > 0 && childElement2 != null) {
+        childElement2!.paint(
+          buffer,
+          Offset(offset.dx, offset.dy + dividerPos + 1),
+        );
       }
     }
   }
 
   int _calculateDividerPos(int totalSize) {
-    final c1 = constraint1;
-    final c2 = constraint2;
+    final split = widget as SplitPane;
+    final c1 = split.constraint1;
+    final c2 = split.constraint2;
 
     if (c1 is LengthConstraint) {
       return c1.length.clamp(0, totalSize - 1);
@@ -202,32 +288,35 @@ class SplitPane extends Widget {
 
   /// Intercepts mouse drag/press events over the divider.
   void handleMouseEvent(MouseEvent event, int localX, int localY) {
-    if (_lastArea == null) return;
-    _initLimits();
-    final totalSize = direction == LayoutDirection.horizontal
-        ? _lastArea!.width
-        : _lastArea!.height;
+    final split = widget as SplitPane;
+    if (split._lastArea == null) return;
+    split._initLimits();
+    final totalSize = split.direction == LayoutDirection.horizontal
+        ? split._lastArea!.width
+        : split._lastArea!.height;
     if (totalSize <= 0) return;
 
-    final mousePos = direction == LayoutDirection.horizontal ? localX : localY;
+    final mousePos = split.direction == LayoutDirection.horizontal
+        ? localX
+        : localY;
 
     if (event.type == MouseEventType.press) {
-      if (mousePos == _dividerX) {
-        _isDragging = true;
+      if (mousePos == split._dividerX) {
+        split._isDragging = true;
       }
     } else if (event.type == MouseEventType.release) {
-      _isDragging = false;
-    } else if (event.type == MouseEventType.drag && _isDragging) {
+      split._isDragging = false;
+    } else if (event.type == MouseEventType.drag && split._isDragging) {
       int newDividerPos = mousePos;
 
       // Solve bounds/limits
-      int minW1 = _origMin1 ?? 0;
-      int maxW1 = _origMax1 ?? (totalSize - 1);
-      if (_origMin2 != null) {
-        maxW1 = min(maxW1, totalSize - _origMin2! - 1);
+      int minW1 = split._origMin1 ?? 0;
+      int maxW1 = split._origMax1 ?? (totalSize - 1);
+      if (split._origMin2 != null) {
+        maxW1 = min(maxW1, totalSize - split._origMin2! - 1);
       }
-      if (_origMax2 != null) {
-        minW1 = max(minW1, totalSize - _origMax2! - 1);
+      if (split._origMax2 != null) {
+        minW1 = max(minW1, totalSize - split._origMax2! - 1);
       }
       minW1 = minW1.clamp(0, totalSize - 1);
       maxW1 = maxW1.clamp(0, totalSize - 1);
@@ -236,35 +325,37 @@ class SplitPane extends Widget {
       newDividerPos = newDividerPos.clamp(minW1, maxW1);
 
       // Mutate constraints in place
-      final c1 = constraint1;
+      final c1 = split.constraint1;
       if (c1 is LengthConstraint) {
-        constraint1 = LengthConstraint(newDividerPos);
-        constraint2 = LengthConstraint(totalSize - newDividerPos - 1);
+        split.constraint1 = LengthConstraint(newDividerPos);
+        split.constraint2 = LengthConstraint(totalSize - newDividerPos - 1);
       } else if (c1 is PercentageConstraint) {
         final p1 = (newDividerPos * 100 / totalSize).round().clamp(0, 100);
-        constraint1 = PercentageConstraint(p1);
-        constraint2 = PercentageConstraint(100 - p1);
+        split.constraint1 = PercentageConstraint(p1);
+        split.constraint2 = PercentageConstraint(100 - p1);
       } else if (c1 is FlexConstraint) {
-        constraint1 = FlexConstraint(newDividerPos);
-        constraint2 = FlexConstraint(totalSize - newDividerPos - 1);
+        split.constraint1 = FlexConstraint(newDividerPos);
+        split.constraint2 = FlexConstraint(totalSize - newDividerPos - 1);
       } else if (c1 is MinMaxConstraint) {
         // Here we keep the min limits but update the current value via a new MinMaxConstraint.
         // Wait, since MinMaxConstraint uses min to represent the preferred size, we update the min.
         // But the original min limit is stored in _origMin1, so we still clamp correctly.
-        constraint1 = MinMaxConstraint(
+        split.constraint1 = MinMaxConstraint(
           min: newDividerPos,
-          max: _origMax1 ?? 99999,
+          max: split._origMax1 ?? 99999,
         );
-        if (constraint2 is MinMaxConstraint) {
-          constraint2 = MinMaxConstraint(
+        if (split.constraint2 is MinMaxConstraint) {
+          split.constraint2 = MinMaxConstraint(
             min: totalSize - newDividerPos - 1,
-            max: _origMax2 ?? 99999,
+            max: split._origMax2 ?? 99999,
           );
         } else {
-          constraint2 = MinMaxConstraint(min: totalSize - newDividerPos - 1);
+          split.constraint2 = MinMaxConstraint(
+            min: totalSize - newDividerPos - 1,
+          );
         }
       }
-      _dividerX = newDividerPos;
+      split._dividerX = newDividerPos;
     }
   }
 }

--- a/packages/termui/lib/ui/widgets/tab_bar.dart
+++ b/packages/termui/lib/ui/widgets/tab_bar.dart
@@ -145,16 +145,43 @@ class TabBar extends Widget {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
+  Element createElement() => TabBarElement(this);
+}
+
+/// An element that manages the rendering and layout of a [TabBar] widget.
+class TabBarElement extends Element {
+  /// Creates a [TabBarElement] for the given [widget].
+  TabBarElement(TabBar super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final tabBar = widget as TabBar;
+    var w = 0;
+    for (var i = 0; i < tabBar.labels.length; i++) {
+      final label = tabBar.labels[i];
+      final text = ' [ $label ] ';
+      w += text.characters.length;
+    }
+    return constraints.constrain(Size(w, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final viewport = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
+    final tabBar = widget as TabBar;
+    if (size.width <= 0 || size.height <= 0) return;
 
     var currentX = 0;
-    for (var i = 0; i < labels.length; i++) {
-      final label = labels[i];
-      final isActive = (i == controller.index);
-      final style = isActive ? activeStyle : inactiveStyle;
+    for (var i = 0; i < tabBar.labels.length; i++) {
+      final label = tabBar.labels[i];
+      final isActive = (i == tabBar.controller.index);
+      final style = isActive ? tabBar.activeStyle : tabBar.inactiveStyle;
       final text = ' [ $label ] ';
-      buffer.writeString(currentX, 0, text, style);
+      if (currentX + text.characters.length > size.width) break;
+      viewport.writeString(currentX, 0, text, style);
       currentX += text.characters.length;
     }
   }
@@ -192,10 +219,65 @@ class TabPanel extends Widget {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
+  Element createElement() => TabPanelElement(this);
+}
 
-    final activeWidget = children[controller.index];
-    activeWidget.render(buffer, area);
+/// An element that manages the active panel rendering and layout of a [TabPanel] widget.
+class TabPanelElement extends Element {
+  Element? _activeChildElement;
+  int _lastActiveIndex = -1;
+
+  /// Creates a [TabPanelElement] for the given [widget].
+  TabPanelElement(TabPanel super.widget);
+
+  @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    final panel = widget as TabPanel;
+    final activeIndex = panel.controller.index;
+    final activeWidget = panel.children[activeIndex];
+
+    if (_activeChildElement != null &&
+        _lastActiveIndex == activeIndex &&
+        _activeChildElement!.widget.runtimeType == activeWidget.runtimeType) {
+      _activeChildElement!.update(activeWidget);
+    } else {
+      _activeChildElement?.unmount();
+      _activeChildElement = activeWidget.createElement();
+      _activeChildElement!.mount(this);
+      _lastActiveIndex = activeIndex;
+    }
+  }
+
+  @override
+  void visitChildren(void Function(Element child) visitor) {
+    if (_activeChildElement != null) visitor(_activeChildElement!);
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    rebuild();
+    if (_activeChildElement != null) {
+      return _activeChildElement!.layout(constraints);
+    }
+    return constraints.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    if (_activeChildElement != null) {
+      _activeChildElement!.paint(buffer, offset);
+    }
   }
 }

--- a/packages/termui/lib/ui/widgets/table.dart
+++ b/packages/termui/lib/ui/widgets/table.dart
@@ -96,13 +96,6 @@ class Table extends Widget {
 
   @override
   Element createElement() => TableElement(this);
-
-  @override
-  void render(Buffer buffer, Rect area) {
-    // Fallback if rendered outside element tree
-    final el = TableElement(this)..mount(null);
-    el.render(buffer, area);
-  }
 }
 
 /// Mount element class corresponding to [Table], preserving per-cell states.
@@ -110,8 +103,89 @@ class TableElement extends Element {
   /// Caches child elements created for cells with widget values.
   List<List<Element?>> cellElements = [];
 
+  /// Caching column widths resolved during layout.
+  List<int> resolvedColumnWidths = [];
+
+  /// Caching column X offsets computed during layout.
+  List<int> columnXOffsets = [];
+
+  /// Caching total content width of the table.
+  int totalContentWidth = 0;
+
   /// Instantiates the rendering element for the given table.
   TableElement(Table super.widget);
+
+  @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void unmount() {
+    for (final row in cellElements) {
+      for (final el in row) {
+        el?.unmount();
+      }
+    }
+    cellElements.clear();
+    super.unmount();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    final table = widget as Table;
+    // Reconcile cell elements list
+    while (cellElements.length < table.rows.length) {
+      cellElements.add(
+        List.filled(table.headers.length, null, growable: false),
+      );
+    }
+    while (cellElements.length > table.rows.length) {
+      final removed = cellElements.removeLast();
+      for (final el in removed) {
+        el?.unmount();
+      }
+    }
+
+    for (var r = 0; r < table.rows.length; r++) {
+      final rowData = table.rows[r];
+      if (cellElements[r].length != table.headers.length) {
+        for (final el in cellElements[r]) {
+          el?.unmount();
+        }
+        cellElements[r] = List.filled(
+          table.headers.length,
+          null,
+          growable: false,
+        );
+      }
+      for (var c = 0; c < table.headers.length; c++) {
+        final cellData = c < rowData.length ? rowData[c] : '';
+        if (cellData is Widget) {
+          Element? cellEl = cellElements[r][c];
+          if (cellEl != null &&
+              cellEl.widget.runtimeType == cellData.runtimeType) {
+            cellEl.update(cellData);
+          } else {
+            cellEl?.unmount();
+            cellEl = cellData.createElement();
+            cellEl.mount(this);
+            cellElements[r][c] = cellEl;
+          }
+        } else {
+          cellElements[r][c]?.unmount();
+          cellElements[r][c] = null;
+        }
+      }
+    }
+  }
 
   @override
   void visitChildren(void Function(Element child) visitor) {
@@ -123,19 +197,60 @@ class TableElement extends Element {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Size performLayout(BoxConstraints constraints) {
     final table = widget as Table;
+    final width = constraints.hasBoundedWidth ? constraints.maxWidth : 80;
+    final height = constraints.hasBoundedHeight
+        ? constraints.maxHeight
+        : (table.rows.length + 2);
+
+    final usableHeight = height - 2;
+    table.adjustScroll(usableHeight);
+
+    // Calculate column widths
+    resolvedColumnWidths = List<int>.generate(table.headers.length, (c) {
+      return c < table.columnWidths.length ? table.columnWidths[c] : 10;
+    });
+
+    // Compute cell offsets
+    columnXOffsets = [];
+    int startX = 0;
+    for (var c = 0; c < table.headers.length; c++) {
+      columnXOffsets.add(startX);
+      startX += resolvedColumnWidths[c] + 1;
+    }
+    totalContentWidth = startX > 0 ? startX - 1 : 0;
+
+    // Layout child elements
+    for (var r = 0; r < table.rows.length; r++) {
+      for (var c = 0; c < table.headers.length; c++) {
+        final cellEl = cellElements[r][c];
+        if (cellEl != null) {
+          final colWidth = resolvedColumnWidths[c];
+          cellEl.layout(BoxConstraints.tight(Size(colWidth, 1)));
+        }
+      }
+    }
+
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final table = widget as Table;
+    final w = size.width;
+    final h = size.height;
     if (table.headers.isEmpty ||
         table.columnWidths.isEmpty ||
-        area.height <= 2 ||
-        area.width <= 0) {
+        h <= 2 ||
+        w <= 0) {
       return;
     }
 
     // 1. Render Headers
     final headerSb = StringBuffer();
     for (var i = 0; i < table.headers.length; i++) {
-      final width = i < table.columnWidths.length ? table.columnWidths[i] : 10;
+      final width = resolvedColumnWidths[i];
       final text = table.headers[i];
       final chars = text.characters;
       final padded = chars.length >= width
@@ -145,30 +260,18 @@ class TableElement extends Element {
       if (i < table.headers.length - 1) headerSb.write(' ');
     }
     final headerChars = headerSb.toString().characters;
-    final headerStr = headerChars.length >= area.width
-        ? headerChars.take(area.width).toString()
-        : headerChars.toString() + (' ' * (area.width - headerChars.length));
-    buffer.writeString(0, 0, headerStr, table.headerStyle);
+    final headerStr = headerChars.length >= w
+        ? headerChars.take(w).toString()
+        : headerChars.toString() + (' ' * (w - headerChars.length));
+    buffer.writeString(offset.dx, offset.dy, headerStr, table.headerStyle);
 
     // 2. Render Header Divider Line
     final dividerChar = '─';
-    final divider = dividerChar * area.width;
-    buffer.writeString(0, 1, divider, table.borderStyle);
+    final divider = dividerChar * w;
+    buffer.writeString(offset.dx, offset.dy + 1, divider, table.borderStyle);
 
-    // 3. Render Rows with Scroll Adjustment
-    final usableHeight = area.height - 2;
-    table.adjustScroll(usableHeight);
-
-    // Synchronize cell elements list
-    while (cellElements.length < table.rows.length) {
-      cellElements.add(
-        List.filled(table.headers.length, null, growable: false),
-      );
-    }
-    if (cellElements.length > table.rows.length) {
-      cellElements.removeRange(table.rows.length, cellElements.length);
-    }
-
+    // 3. Render Rows
+    final usableHeight = h - 2;
     for (var r = 0; r < usableHeight; r++) {
       final rowIdx = table.scrollOffset + r;
       if (rowIdx >= table.rows.length) break;
@@ -179,34 +282,25 @@ class TableElement extends Element {
 
       int startX = 0;
       for (var c = 0; c < table.headers.length; c++) {
-        final colWidth = c < table.columnWidths.length
-            ? table.columnWidths[c]
-            : 10;
+        final colWidth = resolvedColumnWidths[c];
         final cellData = c < rowData.length ? rowData[c] : '';
+        final cellStartX = columnXOffsets[c];
 
-        final cellRect = Rect(startX, 2 + r, colWidth, 1);
+        final cellRect = Rect(
+          offset.dx + cellStartX,
+          offset.dy + 2 + r,
+          colWidth,
+          1,
+        );
         final vp = Viewport(buffer, cellRect);
 
         if (cellData is Widget) {
-          // Pre-fill cell viewport with space using currentStyle
           vp.fill(Cell(' ', currentStyle));
-
-          // Mount / update child element
-          Element? cellEl = cellElements[rowIdx][c];
-          if (cellEl != null &&
-              cellEl.widget.runtimeType == cellData.runtimeType) {
-            cellEl.update(cellData);
-          } else {
-            cellEl = cellData.createElement();
-            cellEl.mount(this);
-            cellElements[rowIdx][c] = cellEl;
+          final cellEl = cellElements[rowIdx][c];
+          if (cellEl != null) {
+            cellEl.paint(vp, Offset.zero);
           }
-
-          cellEl.render(vp, Rect(0, 0, colWidth, 1));
-          // We do NOT apply selection style on top of the rendered cell cells
-          // to prevent negative image and custom styling override.
         } else {
-          // Standard text rendering
           final cellText = cellData.toString();
           final chars = cellText.characters;
           final padded = chars.length >= colWidth
@@ -215,21 +309,29 @@ class TableElement extends Element {
           vp.writeString(0, 0, padded, currentStyle);
         }
 
-        // Render spacing between columns
         if (c < table.headers.length - 1) {
-          final sepX = startX + colWidth;
-          if (sepX < area.width) {
-            buffer.writeString(sepX, 2 + r, ' ', currentStyle);
+          final sepX = cellStartX + colWidth;
+          if (sepX < w) {
+            buffer.writeString(
+              offset.dx + sepX,
+              offset.dy + 2 + r,
+              ' ',
+              currentStyle,
+            );
           }
         }
 
         startX += colWidth + 1;
       }
 
-      // Pad remainder of the row to fill area.width
-      if (startX < area.width) {
-        final remainder = area.width - startX;
-        buffer.writeString(startX, 2 + r, ' ' * remainder, currentStyle);
+      if (startX < w) {
+        final remainder = w - startX;
+        buffer.writeString(
+          offset.dx + startX,
+          offset.dy + 2 + r,
+          ' ' * remainder,
+          currentStyle,
+        );
       }
     }
   }

--- a/packages/termui/lib/ui/widgets/text.dart
+++ b/packages/termui/lib/ui/widgets/text.dart
@@ -83,17 +83,7 @@ class Text extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
-
-    if (!wrap) {
-      final lines = [data];
-      _renderLines(buffer, area, lines);
-    } else {
-      final lines = _wrapText(data, area.width);
-      _renderLines(buffer, area, lines);
-    }
-  }
+  Element createElement() => TextElement(this);
 
   @override
   int getIntrinsicHeight(int width) {
@@ -103,35 +93,6 @@ class Text extends Widget {
     final lines = _wrapText(data, width);
     final count = lines.length;
     return maxLines != null ? min(maxLines!, count) : count;
-  }
-
-  void _renderLines(Buffer buffer, Rect area, List<String> lines) {
-    final limit = maxLines != null ? min(maxLines!, area.height) : area.height;
-    for (var i = 0; i < lines.length; i++) {
-      if (i >= limit) break;
-      final line = lines[i];
-      final lineWidth = measureStringWidth(line);
-
-      var startX = 0;
-      switch (textAlign) {
-        case TextAlign.left:
-          startX = 0;
-          break;
-        case TextAlign.right:
-          startX = max(0, area.width - lineWidth);
-          break;
-        case TextAlign.center:
-          startX = max(0, (area.width - lineWidth) ~/ 2);
-          break;
-        case TextAlign.justify:
-          // Fallback to left-align for justify in basic TUI cells
-          startX = 0;
-          break;
-      }
-
-      final visibleChars = _truncateToWidth(line, area.width - startX);
-      buffer.writeString(startX, i, visibleChars, style);
-    }
   }
 
   String _truncateToWidth(String text, int maxWidth) {
@@ -239,5 +200,85 @@ class Text extends Widget {
     }
 
     return lines;
+  }
+}
+
+/// An element that represents a [Text] widget.
+class TextElement extends Element {
+  List<String> _cachedLines = [];
+
+  /// Creates a text element for a [Text] widget.
+  TextElement(Text super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final textWidget = widget as Text;
+    final width = constraints.maxWidth == BoxConstraints.infinity
+        ? 999999
+        : constraints.maxWidth;
+
+    if (!textWidget.wrap) {
+      _cachedLines = [textWidget.data];
+    } else {
+      _cachedLines = textWidget._wrapText(textWidget.data, width);
+    }
+
+    final limit = textWidget.maxLines != null
+        ? min(textWidget.maxLines!, _cachedLines.length)
+        : _cachedLines.length;
+
+    var measuredWidth = 0;
+    for (var i = 0; i < limit; i++) {
+      final lineW = measureStringWidth(_cachedLines[i]);
+      if (lineW > measuredWidth) {
+        measuredWidth = lineW;
+      }
+    }
+
+    final height = limit;
+    return constraints.constrain(Size(measuredWidth, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final textWidget = widget as Text;
+    final area = Rect(offset.dx, offset.dy, size.width, size.height);
+
+    final limit = textWidget.maxLines != null
+        ? min(textWidget.maxLines!, area.height)
+        : area.height;
+
+    for (var i = 0; i < _cachedLines.length; i++) {
+      if (i >= limit) break;
+      final line = _cachedLines[i];
+      final lineWidth = measureStringWidth(line);
+
+      var startX = 0;
+      switch (textWidget.textAlign) {
+        case TextAlign.left:
+          startX = 0;
+          break;
+        case TextAlign.right:
+          startX = max(0, area.width - lineWidth);
+          break;
+        case TextAlign.center:
+          startX = max(0, (area.width - lineWidth) ~/ 2);
+          break;
+        case TextAlign.justify:
+          startX = 0;
+          break;
+      }
+
+      final visibleChars = textWidget._truncateToWidth(
+        line,
+        area.width - startX,
+      );
+      buffer.writeString(
+        area.x + startX,
+        area.y + i,
+        visibleChars,
+        textWidget.style,
+      );
+    }
   }
 }

--- a/packages/termui/lib/ui/widgets/text_field.dart
+++ b/packages/termui/lib/ui/widgets/text_field.dart
@@ -339,6 +339,12 @@ class TextField extends StatefulWidget implements Focusable {
   /// Custom key mappings for input actions.
   final Map<TextFieldShortcut, TextFieldAction>? customShortcuts;
 
+  /// Optional custom FocusNode to manage this text field's focus.
+  final FocusNode? focusNode;
+
+  /// Optional callback executed when focus status transitions.
+  final void Function(bool hasFocus)? onFocusChange;
+
   /// Vertical scroll offset.
   int scrollOffset = 0;
 
@@ -356,6 +362,8 @@ class TextField extends StatefulWidget implements Focusable {
     this.placeholderStyle = const Style(foreground: Color(128, 128, 128)),
     this.focused = true,
     this.customShortcuts,
+    this.focusNode,
+    this.onFocusChange,
   }) : controller =
            controller ?? TextEditingController(text: value ?? initialText) {
     if (cursorPosition != null && controller == null) {
@@ -859,7 +867,8 @@ class TextFieldState extends State<TextField> implements KeyEventHandler {
   @override
   void initState() {
     super.initState();
-    _focusNode = FocusNode(id: 'textfield_${widget.hashCode}');
+    _focusNode =
+        widget.focusNode ?? FocusNode(id: 'textfield_${widget.hashCode}');
     _updateListener();
     if (widget.focused) {
       scheduleMicrotask(() {
@@ -872,6 +881,13 @@ class TextFieldState extends State<TextField> implements KeyEventHandler {
   void didUpdateWidget(TextField oldWidget) {
     super.didUpdateWidget(oldWidget);
     _updateListener();
+    if (widget.focusNode != oldWidget.focusNode) {
+      if (oldWidget.focusNode == null) {
+        _focusNode.dispose();
+      }
+      _focusNode =
+          widget.focusNode ?? FocusNode(id: 'textfield_${widget.hashCode}');
+    }
     if (widget.focused != oldWidget.focused) {
       if (widget.focused) {
         _focusNode.requestFocus();
@@ -884,7 +900,9 @@ class TextFieldState extends State<TextField> implements KeyEventHandler {
   @override
   void dispose() {
     _listenedController?.removeListener(_onControllerChanged);
-    _focusNode.dispose();
+    if (widget.focusNode == null) {
+      _focusNode.dispose();
+    }
     super.dispose();
   }
 
@@ -895,6 +913,7 @@ class TextFieldState extends State<TextField> implements KeyEventHandler {
       focusNode: _focusNode,
       onFocusChange: (hasFocus) {
         widget.focused = hasFocus;
+        widget.onFocusChange?.call(hasFocus);
         setState(() {}); // Redraw cursor highlight
       },
       onKeyEvent: (event) {
@@ -906,44 +925,77 @@ class TextFieldState extends State<TextField> implements KeyEventHandler {
 }
 
 class _TextFieldRenderWidget extends Widget {
-  final TextField widget;
-  const _TextFieldRenderWidget(this.widget);
+  /// The parent TextField widget configuration.
+  final TextField textFieldWidget;
+
+  /// Creates a render proxy for a TextField.
+  const _TextFieldRenderWidget(this.textFieldWidget);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
+  Element createElement() => _TextFieldRenderWidgetElement(this);
+}
 
-    widget.adjustScroll(area.height);
+/// Element that performs layout and paint for [_TextFieldRenderWidget].
+class _TextFieldRenderWidgetElement extends Element {
+  /// Instantiates the rendering element for the given [_TextFieldRenderWidget].
+  _TextFieldRenderWidgetElement(_TextFieldRenderWidget super.widget);
 
-    final textToRender = widget.value.isEmpty ? widget.placeholder : '';
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final renderWidget = widget as _TextFieldRenderWidget;
+    final textField = renderWidget.textFieldWidget;
+    final width = constraints.hasBoundedWidth ? constraints.maxWidth : 80;
+    final height = constraints.hasBoundedHeight
+        ? constraints.maxHeight
+        : textField.controller.value.lines.length;
+
+    textField.adjustScroll(height);
+
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final renderWidget = widget as _TextFieldRenderWidget;
+    final textField = renderWidget.textFieldWidget;
+    final w = size.width;
+    final h = size.height;
+    if (w <= 0 || h <= 0) return;
+
+    final textToRender = textField.value.isEmpty ? textField.placeholder : '';
     if (textToRender.isNotEmpty) {
-      buffer.writeString(0, 0, textToRender, widget.placeholderStyle);
-      if (widget.focused) {
-        final cell = buffer.getCell(0, 0);
+      buffer.writeString(
+        offset.dx,
+        offset.dy,
+        textToRender,
+        textField.placeholderStyle,
+      );
+      if (textField.focused) {
+        final cell = buffer.getCell(offset.dx, offset.dy);
         if (cell != null) {
-          cell.style = widget.cursorStyle;
+          cell.style = textField.cursorStyle;
         }
       }
       return;
     }
 
-    final lines = widget.controller.value.lines;
-    final cursorLine = widget.cursorLine;
-    final cursorColumn = widget.cursorColumn;
+    final lines = textField.controller.value.lines;
+    final cursorLine = textField.cursorLine;
+    final cursorColumn = textField.cursorColumn;
 
-    for (var y = 0; y < area.height; y++) {
-      final lineIdx = widget.scrollOffset + y;
+    for (var y = 0; y < h; y++) {
+      final lineIdx = textField.scrollOffset + y;
       if (lineIdx >= lines.length) break;
 
       final line = lines[lineIdx];
       final charsList = line.characters.toList();
 
-      for (var x = 0; x < area.width; x++) {
+      for (var x = 0; x < w; x++) {
         final char = x < charsList.length ? charsList[x] : ' ';
         final isCursor =
-            widget.focused && lineIdx == cursorLine && x == cursorColumn;
-        final cellStyle = isCursor ? widget.cursorStyle : widget.style;
-        final cell = buffer.getCell(x, y);
+            textField.focused && lineIdx == cursorLine && x == cursorColumn;
+        final cellStyle = isCursor ? textField.cursorStyle : textField.style;
+        final cell = buffer.getCell(offset.dx + x, offset.dy + y);
         if (cell != null) {
           cell.char = char;
           cell.style = cellStyle;
@@ -951,14 +1003,14 @@ class _TextFieldRenderWidget extends Widget {
       }
 
       // Render cursor at end of line if needed
-      if (widget.focused &&
+      if (textField.focused &&
           lineIdx == cursorLine &&
           cursorColumn >= charsList.length) {
         final cursorX = charsList.length;
-        if (cursorX < area.width) {
-          final cell = buffer.getCell(cursorX, y);
+        if (cursorX < w) {
+          final cell = buffer.getCell(offset.dx + cursorX, offset.dy + y);
           if (cell != null) {
-            cell.style = widget.cursorStyle;
+            cell.style = textField.cursorStyle;
           }
         }
       }

--- a/packages/termui/lib/ui/widgets/timer_widget.dart
+++ b/packages/termui/lib/ui/widgets/timer_widget.dart
@@ -91,46 +91,72 @@ class TimerWidget extends Widget {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
+  Element createElement() => TimerWidgetElement(this);
+}
 
-    final minutes = duration.inMinutes;
-    final seconds = duration.inSeconds % 60;
+/// An element that manages the rendering and layout of a [TimerWidget] widget.
+class TimerWidgetElement extends Element {
+  /// Creates a [TimerWidgetElement] for the given [widget].
+  TimerWidgetElement(TimerWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final w = constraints.maxWidth == BoxConstraints.infinity
+        ? 10
+        : constraints.maxWidth;
+    final h = constraints.maxHeight == BoxConstraints.infinity
+        ? 2
+        : constraints.maxHeight;
+    return constraints.constrain(Size(w, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final viewport = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
+    final timer = widget as TimerWidget;
+    if (size.width <= 0 || size.height <= 0) return;
+
+    final minutes = timer.duration.inMinutes;
+    final seconds = timer.duration.inSeconds % 60;
 
     final mm = minutes.toString().padLeft(2, '0');
     final ss = seconds.toString().padLeft(2, '0');
 
-    final timeStringLength = 5; // "MM:SS"
-    final startX = ((area.width - timeStringLength) / 2).floor().clamp(
+    const timeStringLength = 5; // "MM:SS"
+    final startX = ((size.width - timeStringLength) / 2).floor().clamp(
       0,
-      area.width,
+      size.width,
     );
 
     // Draw digits & separators
-    if (startX + 5 <= area.width) {
-      buffer.writeString(startX, 0, mm, digitStyle);
-      buffer.writeString(startX + 2, 0, ':', separatorStyle);
-      buffer.writeString(startX + 3, 0, ss, digitStyle);
+    if (startX + 5 <= size.width) {
+      viewport.writeString(startX, 0, mm, timer.digitStyle);
+      viewport.writeString(startX + 2, 0, ':', timer.separatorStyle);
+      viewport.writeString(startX + 3, 0, ss, timer.digitStyle);
     } else {
       // Fallback: draw what fits
-      final fallback = '$mm:$ss'.substring(0, area.width);
-      buffer.writeString(0, 0, fallback, digitStyle);
+      final fallback = '$mm:$ss'.substring(0, size.width);
+      viewport.writeString(0, 0, fallback, timer.digitStyle);
     }
 
-    if (area.height >= 2) {
+    if (size.height >= 2) {
       // Draw progress bar below
-      final progress = initialDuration.inMilliseconds == 0
+      final progress = timer.initialDuration.inMilliseconds == 0
           ? 0.0
-          : duration.inMilliseconds / initialDuration.inMilliseconds;
+          : timer.duration.inMilliseconds /
+                timer.initialDuration.inMilliseconds;
 
-      final progressWidth = area.width;
+      final progressWidth = size.width;
       final filledCount = (progress * progressWidth).round().clamp(
         0,
         progressWidth,
       );
 
       final barText = '█' * filledCount + '░' * (progressWidth - filledCount);
-      buffer.writeString(0, 1, barText, progressStyle);
+      viewport.writeString(0, 1, barText, timer.progressStyle);
     }
   }
 }

--- a/packages/termui/lib/ui/widgets/tree.dart
+++ b/packages/termui/lib/ui/widgets/tree.dart
@@ -288,6 +288,9 @@ class TreeWidgetState<T> extends State<TreeWidget<T>>
 
   @override
   void dispose() {
+    if (widget._state == this) {
+      widget._state = null;
+    }
     _focusNode.dispose();
     super.dispose();
   }
@@ -327,24 +330,51 @@ class _TreeWidgetRenderWidget extends Widget {
   const _TreeWidgetRenderWidget({required this.widget, required this.focused});
 
   @override
-  void render(Buffer buffer, Rect area) {
-    widget._updateFlatNodes();
-    widget.adjustScroll(area.height);
+  Element createElement() => _TreeWidgetElement(this);
+}
 
-    final activeSelectedStyle = focused
-        ? widget.selectedStyle
+class _TreeWidgetElement extends Element {
+  _TreeWidgetElement(_TreeWidgetRenderWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final wWidget = widget as _TreeWidgetRenderWidget;
+    wWidget.widget._updateFlatNodes();
+    final w = constraints.maxWidth == BoxConstraints.infinity
+        ? 20
+        : constraints.maxWidth;
+    final h = constraints.maxHeight == BoxConstraints.infinity
+        ? wWidget.widget.flatNodes.length
+        : constraints.maxHeight;
+    return constraints.constrain(Size(w, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final viewport = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
+    final wWidget = widget as _TreeWidgetRenderWidget;
+    final tWidget = wWidget.widget;
+
+    tWidget._updateFlatNodes();
+    tWidget.adjustScroll(size.height);
+
+    final activeSelectedStyle = wWidget.focused
+        ? tWidget.selectedStyle
         : Style(
-            foreground: widget.selectedStyle.foreground,
+            foreground: tWidget.selectedStyle.foreground,
             background: CharmColors.char,
-            modifiers: widget.selectedStyle.modifiers,
+            modifiers: tWidget.selectedStyle.modifiers,
           );
 
-    final nodes = widget.flatNodes;
-    final offset = widget.scrollOffset;
-    final selIdx = widget.selectedIndex;
+    final nodes = tWidget.flatNodes;
+    final scrollOffsetVal = tWidget.scrollOffset;
+    final selIdx = tWidget.selectedIndex;
 
-    for (var i = 0; i < area.height; i++) {
-      final nodeIdx = offset + i;
+    for (var i = 0; i < size.height; i++) {
+      final nodeIdx = scrollOffsetVal + i;
       if (nodeIdx >= nodes.length) break;
 
       final flat = nodes[nodeIdx];
@@ -354,58 +384,58 @@ class _TreeWidgetRenderWidget extends Widget {
 
       // 1. Ancestor guide lines
       for (var depthIdx = 0; depthIdx < flat.depth - 1; depthIdx++) {
-        if (x >= area.width) break;
+        if (x >= size.width) break;
         final isLast = flat.ancestorIsLast[depthIdx];
         final part = isLast ? '   ' : '│  ';
-        buffer.writeString(
-          area.x + x,
-          area.y + i,
+        viewport.writeString(
+          x,
+          i,
           part,
-          isSelected ? activeSelectedStyle : widget.lineStyle,
+          isSelected ? activeSelectedStyle : tWidget.lineStyle,
         );
         x += 3;
       }
 
       // 2. Active node guide line
-      if (flat.depth > 0 && x < area.width) {
+      if (flat.depth > 0 && x < size.width) {
         final isLast = flat.ancestorIsLast.last;
         final part = isLast ? '└── ' : '├── ';
-        buffer.writeString(
-          area.x + x,
-          area.y + i,
+        viewport.writeString(
+          x,
+          i,
           part,
-          isSelected ? activeSelectedStyle : widget.lineStyle,
+          isSelected ? activeSelectedStyle : tWidget.lineStyle,
         );
         x += 4;
       }
 
       // 3. Expander indicator
-      if (x < area.width) {
+      if (x < size.width) {
         final indicator = flat.node.isLeaf
             ? '  '
             : (flat.node.isExpanded ? '▼ ' : '▶ ');
-        buffer.writeString(
-          area.x + x,
-          area.y + i,
+        viewport.writeString(
+          x,
+          i,
           indicator,
-          isSelected ? activeSelectedStyle : widget.lineStyle,
+          isSelected ? activeSelectedStyle : tWidget.lineStyle,
         );
         x += 2;
       }
 
       // 4. Label
-      final remainingWidth = area.width - x;
+      final remainingWidth = size.width - x;
       if (remainingWidth > 0) {
         final labelChars = flat.node.label.characters;
         final labelText = labelChars.length > remainingWidth
             ? labelChars.take(remainingWidth).toString()
             : labelChars.toString() +
                   (' ' * (remainingWidth - labelChars.length));
-        buffer.writeString(
-          area.x + x,
-          area.y + i,
+        viewport.writeString(
+          x,
+          i,
           labelText,
-          isSelected ? activeSelectedStyle : widget.unselectedStyle,
+          isSelected ? activeSelectedStyle : tWidget.unselectedStyle,
         );
       }
     }

--- a/packages/termui/lib/ui/window.dart
+++ b/packages/termui/lib/ui/window.dart
@@ -290,82 +290,7 @@ class Window extends Widget {
        focusNode = focusNode ?? FocusNode(id: title);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (bounds.width <= 0 || bounds.height <= 0) return;
-
-    // Render window inside parent buffer at this window's bounds.
-    final absoluteBounds = Rect(
-      area.x + bounds.x,
-      area.y + bounds.y,
-      bounds.width,
-      bounds.height,
-    );
-
-    final windowViewport = Viewport(buffer, absoluteBounds);
-    final w = bounds.width;
-    final h = bounds.height;
-
-    if (w < 2 || h < 2) {
-      for (var y = 0; y < h; y++) {
-        for (var x = 0; x < w; x++) {
-          final cell = windowViewport.getCell(x, y);
-          if (cell != null) {
-            cell.char = ' ';
-            cell.style = borderStyle;
-          }
-        }
-      }
-      return;
-    }
-
-    // Draw top border
-    final topBorder =
-        borderChars[0] + borderChars[1] * (w - 2) + borderChars[2];
-    windowViewport.writeString(0, 0, topBorder, borderStyle);
-
-    // Overlay title
-    if (title.isNotEmpty) {
-      final titleChars = title.characters;
-      final maxTitleLen = w - 4;
-      String displayedTitle;
-      if (titleChars.length > maxTitleLen) {
-        final cutLen = w - 7;
-        if (cutLen > 0) {
-          displayedTitle = ' ${titleChars.take(cutLen).toString()}... ';
-        } else {
-          displayedTitle = '';
-        }
-      } else {
-        displayedTitle = ' $title ';
-      }
-
-      if (displayedTitle.isNotEmpty) {
-        final dispChars = displayedTitle.characters;
-        final titleX = max(1, min(w - 2, ((w - dispChars.length) / 2).floor()));
-        windowViewport.writeString(titleX, 0, displayedTitle, titleStyle);
-      }
-    }
-
-    // Side borders
-    for (var y = 1; y < h - 1; y++) {
-      windowViewport.writeString(0, y, borderChars[3], borderStyle);
-      windowViewport.writeString(w - 1, y, borderChars[5], borderStyle);
-    }
-
-    // Bottom border
-    final bottomBorder =
-        borderChars[6] + borderChars[7] * (w - 2) + borderChars[8];
-    windowViewport.writeString(0, h - 1, bottomBorder, borderStyle);
-
-    // Render child content viewport
-    final contentArea = Rect(1, 1, w - 2, h - 2);
-    final contentViewport = Viewport(windowViewport, contentArea);
-    contentViewport.fill(Cell(' ', backgroundStyle));
-    child.render(
-      contentViewport,
-      Rect(0, 0, contentArea.width, contentArea.height),
-    );
-  }
+  Element createElement() => WindowElement(this);
 
   /// Returns true if the local coordinates [localX] and [localY] lie on the title text.
   bool isPositionOnTitle(int localX, int localY) {
@@ -391,6 +316,165 @@ class Window extends Widget {
     final dispChars = displayedTitle.characters;
     final titleX = max(1, min(w - 2, ((w - dispChars.length) / 2).floor()));
     return localX >= titleX && localX < titleX + dispChars.length;
+  }
+}
+
+/// Element class corresponding to [Window], managing child reconciliation, layout and paint.
+class WindowElement extends Element {
+  /// The element corresponding to the built child widget.
+  Element? childElement;
+
+  /// Instantiates the rendering element for the given Window.
+  WindowElement(Window super.widget);
+
+  @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    rebuild();
+  }
+
+  @override
+  void unmount() {
+    childElement?.unmount();
+    super.unmount();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    rebuild();
+  }
+
+  @override
+  void rebuild() {
+    final win = widget as Window;
+    if (childElement != null &&
+        childElement!.widget.runtimeType == win.child.runtimeType) {
+      childElement!.update(win.child);
+    } else {
+      childElement?.unmount();
+      childElement = win.child.createElement();
+      childElement!.mount(this);
+    }
+  }
+
+  @override
+  void visitChildren(void Function(Element child) visitor) {
+    if (childElement != null) visitor(childElement!);
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final win = widget as Window;
+    final width = win.bounds.width;
+    final height = win.bounds.height;
+
+    if (childElement != null) {
+      final childW = max(0, width - 2);
+      final childH = max(0, height - 2);
+      childElement!.layout(BoxConstraints.tight(Size(childW, childH)));
+    }
+
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final win = widget as Window;
+    final w = win.bounds.width;
+    final h = win.bounds.height;
+    final paintOffset = offset + Offset(win.bounds.x, win.bounds.y);
+
+    if (w < 2 || h < 2) {
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
+          final cell = buffer.getCell(paintOffset.dx + x, paintOffset.dy + y);
+          if (cell != null) {
+            cell.char = ' ';
+            cell.style = win.borderStyle;
+          }
+        }
+      }
+      return;
+    }
+
+    // Draw top border
+    final topBorder =
+        win.borderChars[0] + win.borderChars[1] * (w - 2) + win.borderChars[2];
+    buffer.writeString(
+      paintOffset.dx,
+      paintOffset.dy,
+      topBorder,
+      win.borderStyle,
+    );
+
+    // Overlay title
+    if (win.title.isNotEmpty) {
+      final titleChars = win.title.characters;
+      final maxTitleLen = w - 4;
+      String displayedTitle;
+      if (titleChars.length > maxTitleLen) {
+        final cutLen = w - 7;
+        if (cutLen > 0) {
+          displayedTitle = ' ${titleChars.take(cutLen).toString()}... ';
+        } else {
+          displayedTitle = '';
+        }
+      } else {
+        displayedTitle = ' ${win.title} ';
+      }
+
+      if (displayedTitle.isNotEmpty) {
+        final dispChars = displayedTitle.characters;
+        final titleX = max(1, min(w - 2, ((w - dispChars.length) / 2).floor()));
+        buffer.writeString(
+          paintOffset.dx + titleX,
+          paintOffset.dy,
+          displayedTitle,
+          win.titleStyle,
+        );
+      }
+    }
+
+    // Side borders
+    for (var y = 1; y < h - 1; y++) {
+      buffer.writeString(
+        paintOffset.dx,
+        paintOffset.dy + y,
+        win.borderChars[3],
+        win.borderStyle,
+      );
+      buffer.writeString(
+        paintOffset.dx + w - 1,
+        paintOffset.dy + y,
+        win.borderChars[5],
+        win.borderStyle,
+      );
+    }
+
+    // Bottom border
+    final bottomBorder =
+        win.borderChars[6] + win.borderChars[7] * (w - 2) + win.borderChars[8];
+    buffer.writeString(
+      paintOffset.dx,
+      paintOffset.dy + h - 1,
+      bottomBorder,
+      win.borderStyle,
+    );
+
+    // Render child content viewport
+    final contentArea = Rect(
+      paintOffset.dx + 1,
+      paintOffset.dy + 1,
+      w - 2,
+      h - 2,
+    );
+    final contentViewport = Viewport(buffer, contentArea);
+    contentViewport.fill(Cell(' ', win.backgroundStyle));
+
+    if (childElement != null) {
+      childElement!.paint(contentViewport, Offset.zero);
+    }
   }
 }
 

--- a/packages/termui/test/animation_test.dart
+++ b/packages/termui/test/animation_test.dart
@@ -72,13 +72,33 @@ class _TestAnimatedRenderWidget extends Widget {
   const _TestAnimatedRenderWidget(this.state);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Element createElement() => _TestAnimatedRenderElement(this);
+}
+
+class _TestAnimatedRenderElement extends Element {
+  _TestAnimatedRenderElement(_TestAnimatedRenderWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final w = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    final h = constraints.maxHeight == BoxConstraints.infinity
+        ? 0
+        : constraints.maxHeight;
+    return constraints.constrain(Size(w, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = widget as _TestAnimatedRenderWidget;
+    final area = Rect(offset.dx, offset.dy, size.width, size.height);
     for (var y = 0; y < area.height; y++) {
       for (var x = 0; x < area.width; x++) {
-        buffer.setCell(x, y, Cell(' ', Style.empty));
+        buffer.setCell(area.x + x, area.y + y, Cell(' ', Style.empty));
       }
     }
-    state.paintEffects(buffer, area, Style.empty);
+    w.state.paintEffects(buffer, area, Style.empty);
   }
 }
 
@@ -214,7 +234,8 @@ void main() {
       final tree = ElementWidget(widget);
       final buffer = Buffer.blank(5, 5);
 
-      tree.render(buffer, const Rect(0, 0, 5, 5));
+      tree.layout(BoxConstraints.tight(const Size(5, 5)));
+      tree.paint(buffer, Offset.zero);
       final state = tree.findState<TestAnimatedWidgetState>()!;
 
       expect(state.vsyncInterval, equals(const Duration(milliseconds: 8)));
@@ -260,7 +281,8 @@ void main() {
       final tree = ElementWidget(widget);
       final buffer = Buffer.blank(5, 5);
 
-      tree.render(buffer, const Rect(0, 0, 5, 5));
+      tree.layout(BoxConstraints.tight(const Size(5, 5)));
+      tree.paint(buffer, Offset.zero);
       final state = tree.findState<TestAnimatedWidgetState>()!;
 
       expect(state.hasTicker(), isFalse);
@@ -282,7 +304,8 @@ void main() {
       final tree = ElementWidget(widget);
       final buffer = Buffer.blank(5, 5);
 
-      tree.render(buffer, const Rect(0, 0, 5, 5));
+      tree.layout(BoxConstraints.tight(const Size(5, 5)));
+      tree.paint(buffer, Offset.zero);
       final state = tree.findState<TestAnimatedWidgetState>()!;
 
       state.startEffect(const Point(2, 2));
@@ -388,7 +411,8 @@ void main() {
       final buffer = Buffer.blank(10, 3);
 
       // Render base state
-      tree.render(buffer, const Rect(0, 0, 10, 3));
+      tree.layout(BoxConstraints.tight(const Size(10, 3)));
+      tree.paint(buffer, Offset.zero);
       final state = tree.findState<AnimatedButtonState>()!;
 
       expect(state.isHovered, isFalse);
@@ -427,7 +451,8 @@ void main() {
       expect(state.isHovered, isFalse);
 
       // Verify that particles and ripple painted something modified
-      tree.render(buffer, const Rect(0, 0, 10, 3));
+      tree.layout(BoxConstraints.tight(const Size(10, 3)));
+      tree.paint(buffer, Offset.zero);
 
       // Release mouse inside: Pressed deactivates, Hover activates, onPressed called
       btn.handleMouseEvent(

--- a/packages/termui/test/animation_time_test.dart
+++ b/packages/termui/test/animation_time_test.dart
@@ -77,7 +77,9 @@ void main() {
           Spinner.dots(clockStopwatch: MockStopwatch(320)),
         ]);
 
-        layout.render(buffer, Rect(0, 0, width, 1));
+        final elementWrapper = ElementWidget(layout);
+        elementWrapper.layout(BoxConstraints.tight(Size(width, 1)));
+        elementWrapper.paint(buffer, Offset.zero);
 
         // With Row layout, each gets equal width (4 columns out of 20).
         expect(buffer.getCell(0, 0)?.char, '⠋');

--- a/packages/termui/test/audit_hardening_test.dart
+++ b/packages/termui/test/audit_hardening_test.dart
@@ -11,9 +11,28 @@ class MockWidget extends Widget {
   Rect? renderedArea;
 
   @override
-  void render(Buffer buffer, Rect area) {
-    rendered = true;
-    renderedArea = area;
+  Element createElement() => MockElement(this);
+}
+
+class MockElement extends Element {
+  MockElement(MockWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final w = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    final h = constraints.maxHeight == BoxConstraints.infinity
+        ? 0
+        : constraints.maxHeight;
+    return constraints.constrain(Size(w, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = widget as MockWidget;
+    w.rendered = true;
+    w.renderedArea = Rect(offset.dx, offset.dy, size.width, size.height);
   }
 }
 
@@ -61,15 +80,21 @@ void main() {
       final items = [Flexible(child: mock)];
 
       final row = Row(items);
-      row.render(buffer, const Rect(0, 0, 0, 10));
+      final rowEl = row.createElement()..mount(null);
+      rowEl.layout(BoxConstraints.tight(const Size(0, 10)));
+      rowEl.paint(buffer, Offset.zero);
       expect(mock.rendered, isFalse);
 
       final col = Column(items);
-      col.render(buffer, const Rect(0, 0, 10, -5));
+      final colEl = col.createElement()..mount(null);
+      colEl.layout(BoxConstraints.tight(const Size(10, -5)));
+      colEl.paint(buffer, Offset.zero);
       expect(mock.rendered, isFalse);
 
       final stack = Stack([mock]);
-      stack.render(buffer, const Rect(0, 0, -2, 0));
+      final stackEl = stack.createElement()..mount(null);
+      stackEl.layout(BoxConstraints.tight(const Size(-2, 0)));
+      stackEl.paint(buffer, Offset.zero);
       expect(mock.rendered, isFalse);
     });
 
@@ -85,7 +110,11 @@ void main() {
         );
 
         // Width of 1 (too small for borders) should not crash and should not render child
-        win.render(buffer, const Rect(0, 0, 10, 10));
+        final winEl = win.createElement()..mount(null);
+        winEl.layout(
+          BoxConstraints.tight(Size(win.bounds.width, win.bounds.height)),
+        );
+        winEl.paint(buffer, Offset.zero);
         expect(child.rendered, isFalse);
 
         // Width/height <= 0 should return immediately
@@ -94,7 +123,13 @@ void main() {
           bounds: const Rect(0, 0, 0, 0),
           child: child,
         );
-        winZero.render(buffer, const Rect(0, 0, 10, 10));
+        final winZeroEl = winZero.createElement()..mount(null);
+        winZeroEl.layout(
+          BoxConstraints.tight(
+            Size(winZero.bounds.width, winZero.bounds.height),
+          ),
+        );
+        winZeroEl.paint(buffer, Offset.zero);
         expect(child.rendered, isFalse);
       },
     );
@@ -110,10 +145,13 @@ void main() {
       );
 
       // Should clip the title safely without throwing a RangeError/ArgumentError
-      expect(
-        () => win.render(buffer, const Rect(0, 0, 20, 5)),
-        returnsNormally,
-      );
+      expect(() {
+        final el = win.createElement()..mount(null);
+        el.layout(
+          BoxConstraints.tight(Size(win.bounds.width, win.bounds.height)),
+        );
+        el.paint(buffer, Offset.zero);
+      }, returnsNormally);
       expect(win.isPositionOnTitle(3, 0), isTrue);
     });
 
@@ -121,27 +159,30 @@ void main() {
       final buffer = Buffer(10, 5);
 
       final label = const Text('🌟✨💫🔥');
-      expect(
-        () => label.render(buffer, const Rect(0, 0, 3, 1)),
-        returnsNormally,
-      );
+      expect(() {
+        final el = label.createElement()..mount(null);
+        el.layout(BoxConstraints.tight(const Size(3, 1)));
+        el.paint(buffer, Offset.zero);
+      }, returnsNormally);
 
       // Paragraph wrapping of long emoji sequences
       final paragraph = Text('🌟✨ 💫🔥💥⚡️🌈');
-      expect(
-        () => paragraph.render(buffer, const Rect(0, 0, 4, 5)),
-        returnsNormally,
-      );
+      expect(() {
+        final el = paragraph.createElement()..mount(null);
+        el.layout(BoxConstraints.tight(const Size(4, 5)));
+        el.paint(buffer, Offset.zero);
+      }, returnsNormally);
     });
 
     test('ListWidget, Table, and NumberSelector handle emojis safely', () {
       final buffer = Buffer(20, 10);
 
       final list = ListWidget(['🌟 item 1', '🔥 item 2']);
-      expect(
-        () => list.render(buffer, const Rect(0, 0, 10, 5)),
-        returnsNormally,
-      );
+      expect(() {
+        final el = list.createElement()..mount(null);
+        el.layout(BoxConstraints.tight(const Size(10, 5)));
+        el.paint(buffer, Offset.zero);
+      }, returnsNormally);
 
       final table = Table(
         headers: ['Header 🌟', 'Header 2'],
@@ -150,10 +191,11 @@ void main() {
         ],
         columnWidths: [10, 8],
       );
-      expect(
-        () => table.render(buffer, const Rect(0, 0, 20, 5)),
-        returnsNormally,
-      );
+      expect(() {
+        final el = table.createElement()..mount(null);
+        el.layout(BoxConstraints.tight(const Size(20, 5)));
+        el.paint(buffer, Offset.zero);
+      }, returnsNormally);
 
       final selector = NumberSelector(
         label: 'Selector 🌟',
@@ -161,10 +203,11 @@ void main() {
         min: 0,
         max: 10,
       );
-      expect(
-        () => selector.render(buffer, const Rect(0, 0, 20, 1)),
-        returnsNormally,
-      );
+      expect(() {
+        final el = selector.createElement()..mount(null);
+        el.layout(BoxConstraints.tight(const Size(20, 1)));
+        el.paint(buffer, Offset.zero);
+      }, returnsNormally);
     });
   });
 

--- a/packages/termui/test/dashboard_demo_test.dart
+++ b/packages/termui/test/dashboard_demo_test.dart
@@ -13,7 +13,8 @@ void main() {
     final buffer = Buffer.blank(80, 20);
 
     // Initial render
-    rootEl.render(buffer, const Rect(0, 0, 80, 20));
+    rootEl.layout(BoxConstraints.tight(const Size(80, 20)));
+    rootEl.paint(buffer, Offset.zero);
 
     // Find the state dynamically by looking for the DashboardApp widget's element
     StatefulElement? dashboardEl;
@@ -35,7 +36,8 @@ void main() {
 
     // 1. Send 'right' key to focus the action
     appState.handleKeyEvent(const ui.KeyEvent('right', ui.KeyType.right));
-    rootEl.render(buffer, const Rect(0, 0, 80, 20));
+    rootEl.layout(BoxConstraints.tight(const Size(80, 20)));
+    rootEl.paint(buffer, Offset.zero);
     expect(appState.isActionFocused, isTrue);
 
     // Find the DropdownButton element and verify it is focused
@@ -130,7 +132,8 @@ void main() {
     }
 
     simulateGlobalKey(const ui.KeyEvent(' ', ui.KeyType.character));
-    rootEl.render(buffer, const Rect(0, 0, 80, 20));
+    rootEl.layout(BoxConstraints.tight(const Size(80, 20)));
+    rootEl.paint(buffer, Offset.zero);
 
     // Verify dropdown is now open
     overlayOpen = false;
@@ -140,12 +143,14 @@ void main() {
 
     // 3. Move selection down to 'Paused' (index 1)
     simulateGlobalKey(const ui.KeyEvent('down', ui.KeyType.down));
-    rootEl.render(buffer, const Rect(0, 0, 80, 20));
+    rootEl.layout(BoxConstraints.tight(const Size(80, 20)));
+    rootEl.paint(buffer, Offset.zero);
     expect(openOverlayState.selectedIndex, equals(1));
 
     // 4. Confirm selection using 'enter'
     simulateGlobalKey(const ui.KeyEvent('\n', ui.KeyType.enter));
-    rootEl.render(buffer, const Rect(0, 0, 80, 20));
+    rootEl.layout(BoxConstraints.tight(const Size(80, 20)));
+    rootEl.paint(buffer, Offset.zero);
 
     // Verify dropdown is closed and value changed
     overlayOpen = false;

--- a/packages/termui/test/declarative_focus_test.dart
+++ b/packages/termui/test/declarative_focus_test.dart
@@ -30,7 +30,8 @@ void main() {
       );
 
       final buffer = Buffer.blank(10, 10);
-      tree.render(buffer, const Rect(0, 0, 10, 10));
+      tree.layout(BoxConstraints.tight(const Size(10, 10)));
+      tree.paint(buffer, Offset.zero);
 
       // Check parenting
       expect(childNode1.parent, equals(rootScope));

--- a/packages/termui/test/dynamic_form_test.dart
+++ b/packages/termui/test/dynamic_form_test.dart
@@ -24,7 +24,8 @@ void main() {
 
       final tree = ElementWidget(form);
       final buffer = Buffer.blank(20, 10);
-      tree.render(buffer, const Rect(0, 0, 20, 10));
+      tree.layout(BoxConstraints.tight(const Size(20, 10)));
+      tree.paint(buffer, Offset.zero);
 
       final formState = tree.findState<FormState>();
       expect(formState, isNotNull);
@@ -59,7 +60,8 @@ void main() {
 
       final tree = ElementWidget(form);
       final buffer = Buffer.blank(20, 10);
-      tree.render(buffer, const Rect(0, 0, 20, 10));
+      tree.layout(BoxConstraints.tight(const Size(20, 10)));
+      tree.paint(buffer, Offset.zero);
 
       final formState = tree.findState<FormState>()!;
       nameField.value = '';
@@ -80,7 +82,8 @@ void main() {
 
       final tree = ElementWidget(form);
       final buffer = Buffer.blank(20, 10);
-      tree.render(buffer, const Rect(0, 0, 20, 10));
+      tree.layout(BoxConstraints.tight(const Size(20, 10)));
+      tree.paint(buffer, Offset.zero);
 
       final formState = tree.findState<FormState>()!;
       f1.focused = true;
@@ -106,7 +109,8 @@ void main() {
       final tree = ElementWidget(form);
       final buffer = Buffer.blank(20, 10);
       buffer.clear();
-      tree.render(buffer, const Rect(0, 0, 20, 10));
+      tree.layout(BoxConstraints.tight(const Size(20, 10)));
+      tree.paint(buffer, Offset.zero);
 
       final formState = tree.findState<FormState>()!;
 
@@ -123,7 +127,8 @@ void main() {
 
       // Re-render
       buffer.clear();
-      tree.render(buffer, const Rect(0, 0, 20, 10));
+      tree.layout(BoxConstraints.tight(const Size(20, 10)));
+      tree.paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -143,7 +148,8 @@ void main() {
       final form = Form(fields: [field]);
       final tree = ElementWidget(form);
       final buffer = Buffer.blank(20, 10);
-      tree.render(buffer, const Rect(0, 0, 20, 10));
+      tree.layout(BoxConstraints.tight(const Size(20, 10)));
+      tree.paint(buffer, Offset.zero);
 
       expect(field.hasError, isFalse);
 
@@ -165,7 +171,8 @@ void main() {
       final form = Form(fields: [f1, f2]);
       final tree = ElementWidget(form);
       final buffer = Buffer.blank(20, 10);
-      tree.render(buffer, const Rect(0, 0, 20, 10));
+      tree.layout(BoxConstraints.tight(const Size(20, 10)));
+      tree.paint(buffer, Offset.zero);
 
       expect(f1.focused, isTrue);
       expect(f2.focused, isFalse);
@@ -188,7 +195,8 @@ void main() {
       final form = Form(fields: [field]);
       final tree = ElementWidget(form);
       final buffer = Buffer.blank(20, 10);
-      tree.render(buffer, const Rect(0, 0, 20, 10));
+      tree.layout(BoxConstraints.tight(const Size(20, 10)));
+      tree.paint(buffer, Offset.zero);
 
       expect(field.focused, isTrue);
       expect(field.hasError, isFalse);

--- a/packages/termui/test/example_screenshot_test.dart
+++ b/packages/termui/test/example_screenshot_test.dart
@@ -77,7 +77,9 @@ void main() {
         ),
       ]);
 
-      layout.render(buffer, const Rect(0, 0, width, height));
+      final elementWrapper = ElementWidget(layout);
+      elementWrapper.layout(BoxConstraints.tight(const Size(width, height)));
+      elementWrapper.paint(buffer, Offset.zero);
 
       final screenshot = AnsiScreenshot.capture(buffer);
 

--- a/packages/termui/test/geometry_test.dart
+++ b/packages/termui/test/geometry_test.dart
@@ -1,0 +1,169 @@
+import 'package:test/test.dart';
+import 'package:termui/ui/layout.dart';
+
+void main() {
+  group('Size Tests', () {
+    test('Constructor and properties', () {
+      const size = Size(10, 20);
+      expect(size.width, 10);
+      expect(size.height, 20);
+    });
+
+    test('Size.zero constants', () {
+      expect(Size.zero.width, 0);
+      expect(Size.zero.height, 0);
+    });
+
+    test('Equality and Hashcode', () {
+      const size1 = Size(10, 20);
+      const size2 = Size(10, 20);
+      const size3 = Size(10, 21);
+
+      expect(size1, equals(size2));
+      expect(size1, isNot(equals(size3)));
+      expect(size1.hashCode, equals(size2.hashCode));
+      expect(size1.hashCode, isNot(equals(size3.hashCode)));
+    });
+
+    test('toString representation', () {
+      const size = Size(10, 20);
+      expect(size.toString(), 'Size(10, 20)');
+    });
+  });
+
+  group('Offset Tests', () {
+    test('Constructor and properties', () {
+      const offset = Offset(5, -3);
+      expect(offset.dx, 5);
+      expect(offset.dy, -3);
+    });
+
+    test('Offset.zero constants', () {
+      expect(Offset.zero.dx, 0);
+      expect(Offset.zero.dy, 0);
+    });
+
+    test('Addition and subtraction operators', () {
+      const o1 = Offset(2, 3);
+      const o2 = Offset(4, 5);
+
+      final sum = o1 + o2;
+      expect(sum.dx, 6);
+      expect(sum.dy, 8);
+
+      final diff = o1 - o2;
+      expect(diff.dx, -2);
+      expect(diff.dy, -2);
+    });
+
+    test('Equality and Hashcode', () {
+      const o1 = Offset(2, 3);
+      const o2 = Offset(2, 3);
+      const o3 = Offset(2, 4);
+
+      expect(o1, equals(o2));
+      expect(o1, isNot(equals(o3)));
+      expect(o1.hashCode, equals(o2.hashCode));
+      expect(o1.hashCode, isNot(equals(o3.hashCode)));
+    });
+
+    test('toString representation', () {
+      const offset = Offset(2, 3);
+      expect(offset.toString(), 'Offset(2, 3)');
+    });
+  });
+
+  group('BoxConstraints Tests', () {
+    test('Default values', () {
+      const constraints = BoxConstraints();
+      expect(constraints.minWidth, 0);
+      expect(constraints.maxWidth, BoxConstraints.infinity);
+      expect(constraints.minHeight, 0);
+      expect(constraints.maxHeight, BoxConstraints.infinity);
+    });
+
+    test('BoxConstraints.tight constructor', () {
+      final constraints = BoxConstraints.tight(const Size(15, 25));
+      expect(constraints.minWidth, 15);
+      expect(constraints.maxWidth, 15);
+      expect(constraints.minHeight, 25);
+      expect(constraints.maxHeight, 25);
+      expect(constraints.isTight, isTrue);
+    });
+
+    test('BoxConstraints.loose constructor', () {
+      final constraints = BoxConstraints.loose(const Size(15, 25));
+      expect(constraints.minWidth, 0);
+      expect(constraints.maxWidth, 15);
+      expect(constraints.minHeight, 0);
+      expect(constraints.maxHeight, 25);
+      expect(constraints.isTight, isFalse);
+    });
+
+    test('BoxConstraints.tightFor constructor', () {
+      const c1 = BoxConstraints.tightFor(width: 10, height: 20);
+      expect(c1.minWidth, 10);
+      expect(c1.maxWidth, 10);
+      expect(c1.minHeight, 20);
+      expect(c1.maxHeight, 20);
+
+      const c2 = BoxConstraints.tightFor(width: 10);
+      expect(c2.minWidth, 10);
+      expect(c2.maxWidth, 10);
+      expect(c2.minHeight, 0);
+      expect(c2.maxHeight, BoxConstraints.infinity);
+    });
+
+    test('Constrain clamps size correctly', () {
+      const constraints = BoxConstraints(
+        minWidth: 5,
+        maxWidth: 10,
+        minHeight: 5,
+        maxHeight: 10,
+      );
+
+      expect(constraints.constrain(const Size(2, 2)), const Size(5, 5));
+      expect(constraints.constrain(const Size(7, 8)), const Size(7, 8));
+      expect(constraints.constrain(const Size(12, 15)), const Size(10, 10));
+    });
+
+    test('Boundedness checks', () {
+      const c1 = BoxConstraints(maxWidth: 10, maxHeight: 10);
+      expect(c1.hasBoundedWidth, isTrue);
+      expect(c1.hasBoundedHeight, isTrue);
+
+      const c2 = BoxConstraints();
+      expect(c2.hasBoundedWidth, isFalse);
+      expect(c2.hasBoundedHeight, isFalse);
+    });
+
+    test('copyWith works correctly', () {
+      const constraints = BoxConstraints(
+        minWidth: 1,
+        maxWidth: 2,
+        minHeight: 3,
+        maxHeight: 4,
+      );
+
+      final copy = constraints.copyWith(minWidth: 10, maxHeight: 40);
+
+      expect(copy.minWidth, 10);
+      expect(copy.maxWidth, 2);
+      expect(copy.minHeight, 3);
+      expect(copy.maxHeight, 40);
+    });
+
+    test('toString representation', () {
+      const constraints = BoxConstraints(
+        minWidth: 1,
+        maxWidth: 2,
+        minHeight: 3,
+        maxHeight: 4,
+      );
+      expect(
+        constraints.toString(),
+        'BoxConstraints(minWidth: 1, maxWidth: 2, minHeight: 3, maxHeight: 4)',
+      );
+    });
+  });
+}

--- a/packages/termui/test/inkwell_button_test.dart
+++ b/packages/termui/test/inkwell_button_test.dart
@@ -33,7 +33,8 @@ void main() {
       final tree = ElementWidget(btn);
       final buffer = Buffer.blank(10, 4);
 
-      tree.render(buffer, const Rect(0, 0, 10, 4));
+      tree.layout(BoxConstraints.tight(const Size(10, 4)));
+      tree.paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -56,7 +57,8 @@ void main() {
       final buffer = Buffer.blank(10, 4);
 
       // Render first to mount the element and state
-      tree.render(buffer, const Rect(0, 0, 10, 4));
+      tree.layout(BoxConstraints.tight(const Size(10, 4)));
+      tree.paint(buffer, Offset.zero);
 
       final state = tree.findState<InkwellButtonState>()!;
       expect(state.isHovered, isFalse);
@@ -76,7 +78,8 @@ void main() {
       expect(state.isHovered, isTrue);
 
       // Render again to reflect state
-      tree.render(buffer, const Rect(0, 0, 10, 4));
+      tree.layout(BoxConstraints.tight(const Size(10, 4)));
+      tree.paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -104,7 +107,8 @@ void main() {
         final buffer = Buffer.blank(10, 4);
 
         // Render first to mount
-        tree.render(buffer, const Rect(0, 0, 10, 4));
+        tree.layout(BoxConstraints.tight(const Size(10, 4)));
+        tree.paint(buffer, Offset.zero);
 
         final state = tree.findState<InkwellButtonState>()!;
         expect(state.isPressed, isFalse);
@@ -132,7 +136,8 @@ void main() {
         expect(state.rippleProgress, greaterThan(0.0));
 
         // Render pressed state
-        tree.render(buffer, const Rect(0, 0, 10, 4));
+        tree.layout(BoxConstraints.tight(const Size(10, 4)));
+        tree.paint(buffer, Offset.zero);
 
         // Pressed body is at Rect(0, 0, 9, 3), same as normal
         // No shadow should be present
@@ -171,7 +176,8 @@ void main() {
         final tree = ElementWidget(btn);
         final buffer = Buffer.blank(10, 4);
 
-        tree.render(buffer, const Rect(0, 0, 10, 4));
+        tree.layout(BoxConstraints.tight(const Size(10, 4)));
+        tree.paint(buffer, Offset.zero);
         final state = tree.findState<InkwellButtonState>()!;
 
         // Press down inside
@@ -219,7 +225,8 @@ void main() {
       final buffer = Buffer.blank(10, 4);
 
       // Render it. The parent area is 10x4, but the button should render constrained to 8x3.
-      tree.render(buffer, const Rect(0, 0, 10, 4));
+      tree.layout(BoxConstraints.tight(const Size(10, 4)));
+      tree.paint(buffer, Offset.zero);
 
       expect(
         buffer,

--- a/packages/termui/test/layout_builder_test.dart
+++ b/packages/termui/test/layout_builder_test.dart
@@ -1,0 +1,288 @@
+import 'package:test/test.dart';
+import 'package:termui/ui/buffer.dart';
+import 'package:termui/ui/style.dart';
+import 'package:termui/ui/layout.dart';
+import 'package:termui/ui/widget_toolkit.dart';
+
+class TestLeafWidget extends Widget {
+  final String content;
+  const TestLeafWidget(this.content);
+
+  @override
+  Element createElement() => _TestLeafElement(this);
+
+  @override
+  int getIntrinsicHeight(int width) {
+    return 1;
+  }
+}
+
+class _TestLeafElement extends Element {
+  _TestLeafElement(super.widget);
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    buffer.writeString(
+      offset.dx,
+      offset.dy,
+      (widget as TestLeafWidget).content,
+      Style.empty,
+    );
+  }
+}
+
+class TrackingWidget extends Widget {
+  final String label;
+  final void Function()? onMount;
+  final void Function()? onUnmount;
+  final void Function(Widget)? onUpdate;
+
+  const TrackingWidget({
+    required this.label,
+    this.onMount,
+    this.onUnmount,
+    this.onUpdate,
+  });
+
+  @override
+  Element createElement() => TrackingElement(this);
+}
+
+class TrackingElement extends Element {
+  TrackingElement(TrackingWidget super.widget);
+
+  @override
+  void mount(Element? parent) {
+    super.mount(parent);
+    (widget as TrackingWidget).onMount?.call();
+  }
+
+  @override
+  void unmount() {
+    (widget as TrackingWidget).onUnmount?.call();
+    super.unmount();
+  }
+
+  @override
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    (widget as TrackingWidget).onUpdate?.call(newWidget);
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final width = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    return constraints.constrain(Size(width, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final trackWidget = widget as TrackingWidget;
+    buffer.writeString(offset.dx, offset.dy, trackWidget.label, Style.empty);
+  }
+}
+
+void main() {
+  group('LayoutBuilder Tests', () {
+    test(
+      'builder function is called with correct BuildContext and BoxConstraints',
+      () {
+        late BuildContext capturedContext;
+        late BoxConstraints capturedConstraints;
+        var builderCalled = false;
+
+        final widget = LayoutBuilder(
+          builder: (context, constraints) {
+            capturedContext = context;
+            capturedConstraints = constraints;
+            builderCalled = true;
+            return const TestLeafWidget('Hello');
+          },
+        );
+
+        final element = widget.createElement();
+        element.mount(null);
+
+        const testConstraints = BoxConstraints(
+          minWidth: 5,
+          maxWidth: 10,
+          minHeight: 1,
+          maxHeight: 1,
+        );
+        final size = element.layout(testConstraints);
+
+        expect(builderCalled, isTrue);
+        expect(capturedContext, same(element));
+        expect(capturedConstraints.minWidth, 5);
+        expect(capturedConstraints.maxWidth, 10);
+        expect(capturedConstraints.minHeight, 1);
+        expect(capturedConstraints.maxHeight, 1);
+        expect(size.width, 10);
+        expect(size.height, 1);
+
+        element.unmount();
+      },
+    );
+
+    test(
+      'changing constraints dynamically updates built child widget and size',
+      () {
+        final widget = LayoutBuilder(
+          builder: (context, constraints) {
+            if (constraints.maxWidth > 5) {
+              return const TestLeafWidget('Wide');
+            } else {
+              return const TestLeafWidget('Narrow');
+            }
+          },
+        );
+
+        final element = widget.createElement();
+        element.mount(null);
+
+        // Wide constraints
+        final size1 = element.layout(
+          const BoxConstraints(
+            minWidth: 8,
+            maxWidth: 8,
+            minHeight: 1,
+            maxHeight: 1,
+          ),
+        );
+        expect(size1.width, 8);
+
+        final buffer1 = Buffer.blank(8, 1);
+        element.paint(buffer1, Offset.zero);
+        expect(buffer1.getCell(0, 0)?.char, 'W'); // Starts with 'W' from "Wide"
+
+        // Narrow constraints
+        final size2 = element.layout(
+          const BoxConstraints(
+            minWidth: 4,
+            maxWidth: 4,
+            minHeight: 1,
+            maxHeight: 1,
+          ),
+        );
+        expect(size2.width, 4);
+
+        final buffer2 = Buffer.blank(4, 1);
+        element.paint(buffer2, Offset.zero);
+        expect(
+          buffer2.getCell(0, 0)?.char,
+          'N',
+        ); // Starts with 'N' from "Narrow"
+
+        element.unmount();
+      },
+    );
+
+    test(
+      'rebuilding, mounting, updating, and unmounting subtrees inside LayoutBuilder',
+      () {
+        var mountCount = 0;
+        var unmountCount = 0;
+        var updateCount = 0;
+        var label = 'A';
+
+        final widget = LayoutBuilder(
+          builder: (context, constraints) {
+            return TrackingWidget(
+              label: label,
+              onMount: () => mountCount++,
+              onUnmount: () => unmountCount++,
+              onUpdate: (newWidget) => updateCount++,
+            );
+          },
+        );
+
+        final element = widget.createElement();
+        element.mount(null);
+
+        // 1. Initial Layout & Mount
+        final size = element.layout(
+          const BoxConstraints(
+            minWidth: 5,
+            maxWidth: 5,
+            minHeight: 1,
+            maxHeight: 1,
+          ),
+        );
+        expect(size.width, 5);
+        expect(mountCount, 1);
+        expect(unmountCount, 0);
+
+        final buffer1 = Buffer.blank(5, 1);
+        element.paint(buffer1, Offset.zero);
+        expect(buffer1.getCell(0, 0)?.char, 'A');
+
+        // 2. Rebuild with same widget type (updates child)
+        label = 'B';
+        element.rebuild();
+
+        expect(mountCount, 1); // No new mount since type matches
+        expect(updateCount, 1); // Child updated
+        expect(unmountCount, 0);
+
+        final buffer2 = Buffer.blank(5, 1);
+        element.paint(buffer2, Offset.zero);
+        expect(buffer2.getCell(0, 0)?.char, 'B');
+
+        // 3. Update the LayoutBuilder widget itself with a new builder
+        var newBuilderCount = 0;
+        final newLayoutBuilder = LayoutBuilder(
+          builder: (context, constraints) {
+            newBuilderCount++;
+            return TrackingWidget(
+              label: 'C',
+              onMount: () => mountCount++,
+              onUnmount: () => unmountCount++,
+              onUpdate: (newWidget) => updateCount++,
+            );
+          },
+        );
+
+        element.update(newLayoutBuilder); // calls rebuild internally
+
+        expect(newBuilderCount, 1);
+        expect(
+          mountCount,
+          1,
+        ); // Old element was type-compatible, so it was updated
+        expect(updateCount, 2);
+        expect(unmountCount, 0);
+
+        final buffer3 = Buffer.blank(5, 1);
+        element.paint(buffer3, Offset.zero);
+        expect(buffer3.getCell(0, 0)?.char, 'C');
+
+        // 4. Force builder to return different widget type (should unmount old and mount new)
+        var differentBuilderCount = 0;
+        final differentLayoutBuilder = LayoutBuilder(
+          builder: (context, constraints) {
+            differentBuilderCount++;
+            return const TestLeafWidget('Leaf');
+          },
+        );
+
+        element.update(differentLayoutBuilder);
+
+        expect(differentBuilderCount, 1);
+        expect(
+          unmountCount,
+          1,
+        ); // Old TrackingWidget element unmounted because of type mismatch
+
+        final buffer4 = Buffer.blank(5, 1);
+        element.paint(buffer4, Offset.zero);
+        expect(buffer4.getCell(0, 0)?.char, 'L'); // "Leaf"
+
+        // 5. Unmount LayoutBuilder element (unmounts active child subtree)
+        expect(element.parent, isNull);
+        element.unmount();
+      },
+    );
+  });
+}

--- a/packages/termui/test/milestone2_lifecycle_test.dart
+++ b/packages/termui/test/milestone2_lifecycle_test.dart
@@ -1,0 +1,212 @@
+import 'package:test/test.dart';
+import 'package:termui/ui/buffer.dart';
+import 'package:termui/ui/style.dart';
+import 'package:termui/ui/layout.dart';
+
+class SimpleLeafWidget extends Widget {
+  final String content;
+  const SimpleLeafWidget(this.content);
+
+  @override
+  Element createElement() => SimpleLeafElement(this);
+}
+
+class SimpleLeafElement extends Element {
+  SimpleLeafElement(SimpleLeafWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final w = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    return constraints.constrain(Size(w, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = widget as SimpleLeafWidget;
+    buffer.writeString(offset.dx, offset.dy, w.content, Style.empty);
+  }
+}
+
+class SimpleStatelessWidget extends StatelessWidget {
+  final Widget child;
+  const SimpleStatelessWidget({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return child;
+  }
+}
+
+class SimpleStatefulWidget extends StatefulWidget {
+  final Widget child;
+  const SimpleStatefulWidget({required this.child});
+
+  @override
+  State createState() => _SimpleStatefulWidgetState();
+}
+
+class _SimpleStatefulWidgetState extends State<SimpleStatefulWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
+
+class SimpleInheritedWidget extends InheritedWidget {
+  const SimpleInheritedWidget({required super.child});
+
+  @override
+  bool updateShouldNotify(SimpleInheritedWidget oldWidget) => false;
+}
+
+void main() {
+  group('Milestone 2 - Base Lifecycle Separation', () {
+    test('LeafElement layout and paint works correctly', () {
+      final widget = SimpleLeafWidget('Hello');
+      final element = widget.createElement();
+      element.mount(null);
+
+      final size = element.layout(
+        const BoxConstraints(
+          minWidth: 5,
+          maxWidth: 10,
+          minHeight: 1,
+          maxHeight: 1,
+        ),
+      );
+      expect(size.width, 10);
+      expect(size.height, 1);
+      expect(element.size, size);
+      expect(element.constraints?.minWidth, 5);
+
+      final buffer = Buffer.blank(10, 1);
+      element.paint(buffer, Offset.zero);
+
+      final cell = buffer.getCell(0, 0);
+      expect(cell?.char, 'H');
+
+      element.unmount();
+    });
+
+    test('StatelessElement layout and paint propagates correctly', () {
+      final leaf = SimpleLeafWidget('World');
+      final widget = SimpleStatelessWidget(child: leaf);
+      final element = StatelessElement(widget);
+      element.mount(null);
+
+      final size = element.layout(
+        const BoxConstraints(
+          minWidth: 5,
+          maxWidth: 10,
+          minHeight: 1,
+          maxHeight: 1,
+        ),
+      );
+      expect(size.width, 10);
+      expect(size.height, 1);
+      expect(element.size, size);
+
+      final buffer = Buffer.blank(10, 1);
+      element.paint(buffer, Offset.zero);
+
+      final cell = buffer.getCell(0, 0);
+      expect(cell?.char, 'W');
+
+      element.unmount();
+    });
+
+    test('StatefulElement layout and paint propagates correctly', () {
+      final leaf = SimpleLeafWidget('State');
+      final widget = SimpleStatefulWidget(child: leaf);
+      final element = StatefulElement(widget);
+      element.mount(null);
+
+      final size = element.layout(
+        const BoxConstraints(
+          minWidth: 5,
+          maxWidth: 10,
+          minHeight: 1,
+          maxHeight: 1,
+        ),
+      );
+      expect(size.width, 10);
+      expect(size.height, 1);
+      expect(element.size, size);
+
+      final buffer = Buffer.blank(10, 1);
+      element.paint(buffer, Offset.zero);
+
+      final cell = buffer.getCell(0, 0);
+      expect(cell?.char, 'S');
+
+      element.unmount();
+    });
+
+    test('InheritedElement layout and paint propagates correctly', () {
+      final leaf = SimpleLeafWidget('Inherit');
+      final widget = SimpleInheritedWidget(child: leaf);
+      final element = InheritedElement(widget);
+      element.mount(null);
+
+      final size = element.layout(
+        const BoxConstraints(
+          minWidth: 5,
+          maxWidth: 10,
+          minHeight: 1,
+          maxHeight: 1,
+        ),
+      );
+      expect(size.width, 10);
+      expect(size.height, 1);
+      expect(element.size, size);
+
+      final buffer = Buffer.blank(10, 1);
+      element.paint(buffer, Offset.zero);
+
+      final cell = buffer.getCell(0, 0);
+      expect(cell?.char, 'I');
+
+      element.unmount();
+    });
+
+    test('ElementWidget layout and paint exposes cached element', () {
+      final leaf = SimpleLeafWidget('Bridge');
+      final widget = ElementWidget(leaf);
+
+      widget.layout(
+        const BoxConstraints(
+          minWidth: 6,
+          maxWidth: 10,
+          minHeight: 1,
+          maxHeight: 1,
+        ),
+      );
+      expect(widget.element, isNotNull);
+      expect(widget.element!.size.width, 10);
+
+      final buffer = Buffer.blank(10, 1);
+      widget.paint(buffer, Offset.zero);
+
+      final cell = buffer.getCell(0, 0);
+      expect(cell?.char, 'B');
+    });
+
+    test('Element layout and paint performs layout and paint', () {
+      final leaf = SimpleLeafWidget('Fallback');
+      final element = leaf.createElement();
+      element.mount(null);
+
+      final buffer = Buffer.blank(10, 1);
+      element.layout(BoxConstraints.tight(const Size(10, 1)));
+      element.paint(buffer, Offset.zero);
+
+      expect(element.size.width, 10);
+      final cell = buffer.getCell(0, 0);
+      expect(cell?.char, 'F');
+
+      element.unmount();
+    });
+  });
+}

--- a/packages/termui/test/phase1_layout_state_test.dart
+++ b/packages/termui/test/phase1_layout_state_test.dart
@@ -9,15 +9,35 @@ class TestWidget extends Widget {
   const TestWidget(this.char);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (char.length == 1) {
+  Element createElement() => TestWidgetElement(this);
+}
+
+class TestWidgetElement extends Element {
+  TestWidgetElement(TestWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final w = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    final h = constraints.maxHeight == BoxConstraints.infinity
+        ? 0
+        : constraints.maxHeight;
+    return constraints.constrain(Size(w, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = widget as TestWidget;
+    final area = Rect(offset.dx, offset.dy, size.width, size.height);
+    if (w.char.length == 1) {
       for (var y = 0; y < area.height; y++) {
         for (var x = 0; x < area.width; x++) {
-          buffer.setCell(x, y, Cell(char, Style.empty));
+          buffer.setCell(area.x + x, area.y + y, Cell(w.char, Style.empty));
         }
       }
     } else {
-      buffer.writeString(0, 0, char, Style.empty);
+      buffer.writeString(area.x, area.y, w.char, Style.empty);
     }
   }
 }
@@ -102,7 +122,9 @@ void main() {
         child: const TestWidget('X'),
       );
 
-      padding.render(buffer, const Rect(0, 0, 6, 4));
+      final elementWrapper = ElementWidget(padding);
+      elementWrapper.layout(BoxConstraints.tight(const Size(6, 4)));
+      elementWrapper.paint(buffer, Offset.zero);
 
       // Rect bounds: left=2, top=1, right=1, bottom=1.
       // Width = 6 - 2 - 1 = 3. Height = 4 - 1 - 1 = 2.
@@ -125,7 +147,9 @@ void main() {
         const Flexible(flex: 2, child: TestWidget('C')),
       ]);
 
-      row.render(buffer, const Rect(0, 0, 10, 1));
+      final elementWrapper = ElementWidget(row);
+      elementWrapper.layout(BoxConstraints.tight(const Size(10, 1)));
+      elementWrapper.paint(buffer, Offset.zero);
 
       // Total width = 10.
       // Sized child width = 2. Remaining width = 8.
@@ -151,7 +175,9 @@ void main() {
         const Expanded(child: TestWidget('B')),
       ]);
 
-      column.render(buffer, const Rect(0, 0, 1, 6));
+      final elementWrapper = ElementWidget(column);
+      elementWrapper.layout(BoxConstraints.tight(const Size(1, 6)));
+      elementWrapper.paint(buffer, Offset.zero);
 
       // Total height = 6.
       // Sized child = 2. Remaining = 4.
@@ -179,7 +205,9 @@ void main() {
         ),
       ]);
 
-      stack.render(buffer, const Rect(0, 0, 5, 5));
+      final elementWrapper = ElementWidget(stack);
+      elementWrapper.layout(BoxConstraints.tight(const Size(5, 5)));
+      elementWrapper.paint(buffer, Offset.zero);
 
       // Base: A fills entire 5x5.
       // Overlay: B renders at x: [1, 2], y: 2.
@@ -197,7 +225,9 @@ void main() {
         child: const SizedBox(width: 1, height: 1, child: TestWidget('X')),
       );
 
-      center.render(buffer, const Rect(0, 0, 5, 5));
+      final elementWrapper = ElementWidget(center);
+      elementWrapper.layout(BoxConstraints.tight(const Size(5, 5)));
+      elementWrapper.paint(buffer, Offset.zero);
 
       // Buffer size 5x5. Child size 1x1.
       // Centered: remaining = 4. offset = 4 / 2 = 2.
@@ -218,7 +248,8 @@ void main() {
       element.mount(null);
 
       // Render initial state
-      element.render(buffer, const Rect(0, 0, 10, 1));
+      element.layout(BoxConstraints.tight(const Size(10, 1)));
+      element.paint(buffer, Offset.zero);
       expect(buffer.getCell(0, 0)!.char, 'v');
       expect(buffer.getCell(4, 0)!.char, '0');
 
@@ -227,7 +258,8 @@ void main() {
       state.increment();
 
       // Render updated state
-      element.render(buffer, const Rect(0, 0, 10, 1));
+      element.layout(BoxConstraints.tight(const Size(10, 1)));
+      element.paint(buffer, Offset.zero);
       expect(buffer.getCell(4, 0)!.char, '1');
     });
   });
@@ -240,7 +272,8 @@ void main() {
       final element = widget.createElement();
       element.mount(null);
 
-      element.render(buffer, const Rect(0, 0, 5, 1));
+      element.layout(BoxConstraints.tight(const Size(5, 1)));
+      element.paint(buffer, Offset.zero);
       expect(buffer.getCell(0, 0)!.char, 'R');
     });
   });

--- a/packages/termui/test/phase2_decoration_test.dart
+++ b/packages/termui/test/phase2_decoration_test.dart
@@ -23,10 +23,29 @@ class TestWidget extends Widget {
   const TestWidget(this.char);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    for (var y = 0; y < area.height; y++) {
-      for (var x = 0; x < area.width; x++) {
-        buffer.setCell(area.x + x, area.y + y, Cell(char, Style.empty));
+  Element createElement() => TestWidgetElement(this);
+}
+
+class TestWidgetElement extends Element {
+  TestWidgetElement(TestWidget super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    final w = constraints.maxWidth == BoxConstraints.infinity
+        ? 0
+        : constraints.maxWidth;
+    final h = constraints.maxHeight == BoxConstraints.infinity
+        ? 0
+        : constraints.maxHeight;
+    return constraints.constrain(Size(w, h));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = widget as TestWidget;
+    for (var y = 0; y < size.height; y++) {
+      for (var x = 0; x < size.width; x++) {
+        buffer.setCell(offset.dx + x, offset.dy + y, Cell(w.char, Style.empty));
       }
     }
   }
@@ -40,7 +59,8 @@ void main() {
 
       final element = widget.createElement();
       element.mount(null);
-      element.render(buffer, const Rect(0, 0, 1, 1));
+      element.layout(BoxConstraints.tight(const Size(1, 1)));
+      element.paint(buffer, Offset.zero);
 
       // Default dark theme primaryStyle has white foreground
       expect(buffer.getCell(0, 0)!.char, 'W');
@@ -55,7 +75,8 @@ void main() {
 
       final element = widget.createElement();
       element.mount(null);
-      element.render(buffer, const Rect(0, 0, 1, 1));
+      element.layout(BoxConstraints.tight(const Size(1, 1)));
+      element.paint(buffer, Offset.zero);
 
       // Light theme primaryStyle has black foreground
       expect(buffer.getCell(0, 0)!.char, 'B');
@@ -73,7 +94,9 @@ void main() {
         child: const TestWidget('X'),
       );
 
-      widget.render(buffer, const Rect(0, 0, 4, 4));
+      final wrapper = ElementWidget(widget);
+      wrapper.layout(BoxConstraints.tight(const Size(4, 4)));
+      wrapper.paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -91,7 +114,9 @@ void main() {
         child: const TestWidget(' '),
       );
 
-      widget.render(buffer, const Rect(0, 0, 3, 3));
+      final wrapper = ElementWidget(widget);
+      wrapper.layout(BoxConstraints.tight(const Size(3, 3)));
+      wrapper.paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -109,7 +134,9 @@ void main() {
         child: const TestWidget(' '),
       );
 
-      widget.render(buffer, const Rect(0, 0, 3, 3));
+      final wrapper = ElementWidget(widget);
+      wrapper.layout(BoxConstraints.tight(const Size(3, 3)));
+      wrapper.paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -127,7 +154,9 @@ void main() {
         child: const TestWidget(' '),
       );
 
-      widget.render(buffer, const Rect(0, 0, 3, 3));
+      final wrapper = ElementWidget(widget);
+      wrapper.layout(BoxConstraints.tight(const Size(3, 3)));
+      wrapper.paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -150,7 +179,9 @@ void main() {
       final buffer = Buffer.blank(10, 1);
       final widget = const Text('Hello你好', wrap: false);
 
-      widget.render(buffer, const Rect(0, 0, 10, 1));
+      final wrapper = ElementWidget(widget);
+      wrapper.layout(BoxConstraints.tight(const Size(10, 1)));
+      wrapper.paint(buffer, Offset.zero);
       // "Hello你好": Hello is 5, 你好 is 4. Total = 9.
       expect(buffer.getCell(0, 0)!.char, 'H');
       expect(buffer.getCell(5, 0)!.char, '你');
@@ -167,7 +198,9 @@ void main() {
         wrap: false,
       ); // Hello = 5, 你 = 2. Total = 7.
 
-      widget.render(buffer, const Rect(0, 0, 6, 1));
+      final wrapper = ElementWidget(widget);
+      wrapper.layout(BoxConstraints.tight(const Size(6, 1)));
+      wrapper.paint(buffer, Offset.zero);
       // Should show "Hello" and a space since "你" requires 2 cells but only 1 remains.
       expect(buffer.getCell(0, 0)!.char, 'H');
       expect(buffer.getCell(4, 0)!.char, 'o');
@@ -183,7 +216,9 @@ void main() {
       // Line 3: "World" (5).
       final widget = const Text('Hello 你好 😀 World', wrap: true);
 
-      widget.render(buffer, const Rect(0, 0, 8, 3));
+      final wrapper = ElementWidget(widget);
+      wrapper.layout(BoxConstraints.tight(const Size(8, 3)));
+      wrapper.paint(buffer, Offset.zero);
 
       // Line 1
       expect(buffer.getCell(0, 0)!.char, 'H');
@@ -210,21 +245,24 @@ void main() {
       final bufferCenter = Buffer.blank(10, 1);
       final bufferRight = Buffer.blank(10, 1);
 
-      const Text(
-        '你好',
-        wrap: false,
-        textAlign: TextAlign.left,
-      ).render(bufferLeft, const Rect(0, 0, 10, 1));
-      const Text(
+      final wLeft = const Text('你好', wrap: false, textAlign: TextAlign.left);
+      final wrapperLeft = ElementWidget(wLeft);
+      wrapperLeft.layout(BoxConstraints.tight(const Size(10, 1)));
+      wrapperLeft.paint(bufferLeft, Offset.zero);
+
+      final wCenter = const Text(
         '你好',
         wrap: false,
         textAlign: TextAlign.center,
-      ).render(bufferCenter, const Rect(0, 0, 10, 1));
-      const Text(
-        '你好',
-        wrap: false,
-        textAlign: TextAlign.right,
-      ).render(bufferRight, const Rect(0, 0, 10, 1));
+      );
+      final wrapperCenter = ElementWidget(wCenter);
+      wrapperCenter.layout(BoxConstraints.tight(const Size(10, 1)));
+      wrapperCenter.paint(bufferCenter, Offset.zero);
+
+      final wRight = const Text('你好', wrap: false, textAlign: TextAlign.right);
+      final wrapperRight = ElementWidget(wRight);
+      wrapperRight.layout(BoxConstraints.tight(const Size(10, 1)));
+      wrapperRight.paint(bufferRight, Offset.zero);
 
       // Left
       expect(bufferLeft.getCell(0, 0)!.char, '你');

--- a/packages/termui/test/phase3_scroll_input_test.dart
+++ b/packages/termui/test/phase3_scroll_input_test.dart
@@ -12,8 +12,27 @@ class SimpleTextWidget extends Widget {
   const SimpleTextWidget(this.text);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    buffer.writeString(0, 0, text, Style.empty);
+  Element createElement() => _SimpleTextElement(this);
+}
+
+class _SimpleTextElement extends Element {
+  _SimpleTextElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return constraints.constrain(
+      Size((widget as SimpleTextWidget).text.length, 1),
+    );
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    buffer.writeString(
+      offset.dx,
+      offset.dy,
+      (widget as SimpleTextWidget).text,
+      Style.empty,
+    );
   }
 }
 
@@ -87,7 +106,9 @@ void main() {
       );
 
       // Render scroll view inside an area of height 5.
-      scrollView.render(buffer, const Rect(0, 0, 20, 5));
+      ElementWidget(scrollView)
+        ..layout(BoxConstraints.tight(const Size(20, 5)))
+        ..paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -186,7 +207,9 @@ void main() {
       // Verify rendering
       final buffer = Buffer.blank(15, 1);
       buffer.clear();
-      getCheckbox(focused: false).render(buffer, const Rect(0, 0, 15, 1));
+      ElementWidget(getCheckbox(focused: false))
+        ..layout(BoxConstraints.tight(const Size(15, 1)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -210,7 +233,9 @@ void main() {
 
       // Render again
       buffer.clear();
-      getCheckbox(focused: false).render(buffer, const Rect(0, 0, 15, 1));
+      ElementWidget(getCheckbox(focused: false))
+        ..layout(BoxConstraints.tight(const Size(15, 1)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -239,7 +264,9 @@ void main() {
 
       final buffer = Buffer.blank(15, 1);
       buffer.clear();
-      getRadio('B', focused: false).render(buffer, const Rect(0, 0, 15, 1));
+      ElementWidget(getRadio('B', focused: false))
+        ..layout(BoxConstraints.tight(const Size(15, 1)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -256,7 +283,9 @@ void main() {
       expect(groupVal, equals('B'));
 
       buffer.clear();
-      getRadio('B', focused: false).render(buffer, const Rect(0, 0, 15, 1));
+      ElementWidget(getRadio('B', focused: false))
+        ..layout(BoxConstraints.tight(const Size(15, 1)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -277,7 +306,9 @@ void main() {
 
       final buffer = Buffer.blank(15, 1);
       buffer.clear();
-      getSwitch(focused: false).render(buffer, const Rect(0, 0, 15, 1));
+      ElementWidget(getSwitch(focused: false))
+        ..layout(BoxConstraints.tight(const Size(15, 1)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -300,7 +331,9 @@ void main() {
       expect(switchVal, isTrue);
 
       buffer.clear();
-      getSwitch(focused: false).render(buffer, const Rect(0, 0, 15, 1));
+      ElementWidget(getSwitch(focused: false))
+        ..layout(BoxConstraints.tight(const Size(15, 1)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -348,7 +381,9 @@ void main() {
       );
 
       final buffer = Buffer.blank(1, 10);
-      scrollBar.render(buffer, const Rect(0, 0, 1, 10));
+      ElementWidget(scrollBar)
+        ..layout(BoxConstraints.tight(const Size(1, 10)))
+        ..paint(buffer, Offset.zero);
 
       // Click at the exact middle of the 10-line scrollbar (y = 5)
       // clickRatio = 5 / 10 = 0.5.

--- a/packages/termui/test/phase3_test.dart
+++ b/packages/termui/test/phase3_test.dart
@@ -9,8 +9,25 @@ class LabelWidget extends Widget {
   const LabelWidget(this.text);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    buffer.writeString(0, 0, text, Style.empty);
+  Element createElement() => _LabelElement(this);
+}
+
+class _LabelElement extends Element {
+  _LabelElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return constraints.constrain(Size((widget as LabelWidget).text.length, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    buffer.writeString(
+      offset.dx,
+      offset.dy,
+      (widget as LabelWidget).text,
+      Style.empty,
+    );
   }
 }
 
@@ -99,7 +116,9 @@ void main() {
         const Expanded(child: LabelWidget('3')),
       ]);
 
-      layout.render(root, const Rect(0, 0, 10, 10));
+      ElementWidget(layout)
+        ..layout(BoxConstraints.tight(const Size(10, 10)))
+        ..paint(root, Offset.zero);
 
       // Left column (0..4) is handled by Column.
       // Row 0 has LabelWidget('1') -> '1' at (0, 0)
@@ -120,7 +139,9 @@ void main() {
         child: const LabelWidget('Hi'),
       );
 
-      padding.render(root, const Rect(0, 0, 10, 5));
+      ElementWidget(padding)
+        ..layout(BoxConstraints.tight(const Size(10, 5)))
+        ..paint(root, Offset.zero);
 
       // Root buffer starts at (0, 0).
       // Padding adds left=2, top=1.
@@ -142,7 +163,9 @@ void main() {
 
       // Width = 5, padding left=3 + right=3 = 6 (which exceeds 5).
       // Should not crash and should not render anything.
-      padding.render(root, const Rect(0, 0, 5, 5));
+      ElementWidget(padding)
+        ..layout(BoxConstraints.tight(const Size(5, 5)))
+        ..paint(root, Offset.zero);
       for (var y = 0; y < 5; y++) {
         for (var x = 0; x < 5; x++) {
           expect(root.getCell(x, y)!.char, ' ');

--- a/packages/termui/test/phase4_overlays_test.dart
+++ b/packages/termui/test/phase4_overlays_test.dart
@@ -10,8 +10,27 @@ class TestCellWidget extends Widget {
   const TestCellWidget(this.content);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    buffer.writeString(0, 0, content, Style.empty);
+  Element createElement() => _TestCellElement(this);
+}
+
+class _TestCellElement extends Element {
+  _TestCellElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return constraints.constrain(
+      Size((widget as TestCellWidget).content.length, 1),
+    );
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    buffer.writeString(
+      offset.dx,
+      offset.dy,
+      (widget as TestCellWidget).content,
+      Style.empty,
+    );
   }
 }
 
@@ -23,7 +42,9 @@ void main() {
         0.5,
         showPercentage: false,
       );
-      indicator.render(buffer, const Rect(0, 0, 10, 1));
+      ElementWidget(indicator)
+        ..layout(BoxConstraints.tight(const Size(10, 1)))
+        ..paint(buffer, Offset.zero);
 
       // 0.5 of 10 is 5 cells filled
       expect(buffer.getCell(0, 0)!.char, equals('█'));
@@ -71,7 +92,9 @@ void main() {
         columnWidths: [6, 6],
       );
 
-      table.render(buffer, const Rect(0, 0, 20, 4));
+      ElementWidget(table)
+        ..layout(BoxConstraints.tight(const Size(20, 4)))
+        ..paint(buffer, Offset.zero);
 
       // Row 0: Headers
       final row0 = List.generate(
@@ -130,7 +153,8 @@ void main() {
 
       // Lazily run stateful loop
       final rootEl = StatefulElement(overlayWidget)..mount(null);
-      rootEl.render(buffer, const Rect(0, 0, 10, 10));
+      rootEl.layout(BoxConstraints.tight(const Size(10, 10)));
+      rootEl.paint(buffer, Offset.zero);
 
       // E1 rendered at (0, 0)
       expect(buffer.getCell(0, 0)!.char, equals('E'));
@@ -144,7 +168,8 @@ void main() {
       // E2 is removed
       entry2.remove();
       buffer.clear();
-      rootEl.render(buffer, const Rect(0, 0, 10, 10));
+      rootEl.layout(BoxConstraints.tight(const Size(10, 10)));
+      rootEl.paint(buffer, Offset.zero);
 
       expect(buffer.getCell(0, 0)!.char, equals('E'));
       // E2 position is now empty/clear
@@ -165,7 +190,8 @@ void main() {
 
       final rootEl = StatefulElement(app)..mount(null);
       final buffer = Buffer.blank(20, 10);
-      rootEl.render(buffer, const Rect(0, 0, 20, 10));
+      rootEl.layout(BoxConstraints.tight(const Size(20, 10)));
+      rootEl.paint(buffer, Offset.zero);
 
       // Initially closed, shows selection
       // Find DropdownButton element and trigger action
@@ -178,7 +204,8 @@ void main() {
 
       // Open dropdown
       dropState.handleKeyEvent(const KeyEvent(' ', KeyType.character));
-      rootEl.render(buffer, const Rect(0, 0, 20, 10));
+      rootEl.layout(BoxConstraints.tight(const Size(20, 10)));
+      rootEl.paint(buffer, Offset.zero);
 
       // Dropdown menu elements should render below the button (row 1 and row 2)
       // Since first item is selected, row 1 shows 'One'
@@ -188,12 +215,14 @@ void main() {
 
       // Move selection down
       dropState.handleKeyEvent(const KeyEvent('down', KeyType.down));
-      rootEl.render(buffer, const Rect(0, 0, 20, 10));
+      rootEl.layout(BoxConstraints.tight(const Size(20, 10)));
+      rootEl.paint(buffer, Offset.zero);
 
       // Confirm selection
       dropState.handleKeyEvent(const KeyEvent('enter', KeyType.enter));
       buffer.clear();
-      rootEl.render(buffer, const Rect(0, 0, 20, 10));
+      rootEl.layout(BoxConstraints.tight(const Size(20, 10)));
+      rootEl.paint(buffer, Offset.zero);
 
       // Menu is closed, row 1 is now empty/clear
       expect(buffer.getCell(0, 1)!.char, equals(' '));
@@ -218,7 +247,8 @@ void main() {
 
       final rootEl = StatefulElement(app)..mount(null);
       final buffer = Buffer.blank(20, 10);
-      rootEl.render(buffer, const Rect(0, 0, 20, 10));
+      rootEl.layout(BoxConstraints.tight(const Size(20, 10)));
+      rootEl.paint(buffer, Offset.zero);
 
       final stackEl = rootEl.childElement! as StackElement;
       final posEl = stackEl.childElements[0] as PositionedElement;
@@ -229,7 +259,8 @@ void main() {
 
       // Open menu
       menuState.handleKeyEvent(const KeyEvent(' ', KeyType.character));
-      rootEl.render(buffer, const Rect(0, 0, 20, 10));
+      rootEl.layout(BoxConstraints.tight(const Size(20, 10)));
+      rootEl.paint(buffer, Offset.zero);
 
       // Action A should render below the button (row 1)
       expect(buffer.getCell(0, 1)!.char, equals('A'));
@@ -238,7 +269,8 @@ void main() {
       // Select first action
       menuState.handleKeyEvent(const KeyEvent('enter', KeyType.enter));
       buffer.clear();
-      rootEl.render(buffer, const Rect(0, 0, 20, 10));
+      rootEl.layout(BoxConstraints.tight(const Size(20, 10)));
+      rootEl.paint(buffer, Offset.zero);
 
       expect(selectedVal, equals('A'));
       // Menu is closed, row 1 is now empty/clear

--- a/packages/termui/test/phase4_test.dart
+++ b/packages/termui/test/phase4_test.dart
@@ -7,9 +7,22 @@ import 'package:termui/ui/window.dart';
 
 class SimpleWidget extends Widget {
   const SimpleWidget();
+
   @override
-  void render(Buffer buffer, Rect area) {
-    buffer.writeString(0, 0, 'X', Style.empty);
+  Element createElement() => _SimpleElement(this);
+}
+
+class _SimpleElement extends Element {
+  _SimpleElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return constraints.constrain(const Size(1, 1));
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    buffer.writeString(offset.dx, offset.dy, 'X', Style.empty);
   }
 }
 
@@ -235,7 +248,9 @@ void main() {
         child: const SimpleWidget(),
       );
 
-      win.render(buffer, const Rect(0, 0, 15, 10));
+      ElementWidget(win)
+        ..layout(BoxConstraints.tight(const Size(15, 10)))
+        ..paint(buffer, Offset.zero);
 
       // Window bounds: (1, 1) to (10, 5) on buffer
       // Top border corner at (1, 1) is '┌'

--- a/packages/termui/test/phase5_test.dart
+++ b/packages/termui/test/phase5_test.dart
@@ -13,7 +13,9 @@ void main() {
     test('Basic wrapping and forced breaks on constraint shrink', () {
       final buffer = Buffer.blank(10, 5);
       final p1 = Text('Hello standard word wrap');
-      p1.render(buffer, const Rect(0, 0, 10, 5));
+      ElementWidget(p1)
+        ..layout(BoxConstraints.tight(const Size(10, 5)))
+        ..paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -29,7 +31,9 @@ void main() {
       // Forced wrapping of a single word larger than max width
       final p2 = Text('Supercalifragilistic');
       // MaxWidth = 8
-      p2.render(buffer, const Rect(0, 0, 8, 5));
+      ElementWidget(p2)
+        ..layout(BoxConstraints.tight(const Size(8, 5)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -86,7 +90,9 @@ void main() {
       final buffer = Buffer.blank(5, 1);
 
       // When focused
-      input.render(buffer, const Rect(0, 0, 5, 1));
+      ElementWidget(input)
+        ..layout(BoxConstraints.tight(const Size(5, 1)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -98,7 +104,9 @@ void main() {
       // Reset buffer and set focused = false
       buffer.clear();
       input.focused = false;
-      input.render(buffer, const Rect(0, 0, 5, 1));
+      ElementWidget(input)
+        ..layout(BoxConstraints.tight(const Size(5, 1)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -123,7 +131,9 @@ void main() {
         )..cursorColumn = 0;
         final buffer = Buffer.blank(6, 1);
 
-        input.render(buffer, const Rect(0, 0, 6, 1));
+        ElementWidget(input)
+          ..layout(BoxConstraints.tight(const Size(6, 1)))
+          ..paint(buffer, Offset.zero);
 
         expect(
           buffer,
@@ -140,7 +150,9 @@ void main() {
     test('Bar render is filled proportionally and centers percentage', () {
       final buffer = Buffer.blank(10, 1);
       final bar = const LinearProgressIndicator(0.5, showPercentage: true);
-      bar.render(buffer, const Rect(0, 0, 10, 1));
+      ElementWidget(bar)
+        ..layout(BoxConstraints.tight(const Size(10, 1)))
+        ..paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -159,7 +171,9 @@ void main() {
       canvas.setPixel(0, 0, true);
 
       final buffer = Buffer.blank(1, 1);
-      canvas.render(buffer, const Rect(0, 0, 1, 1));
+      ElementWidget(canvas)
+        ..layout(BoxConstraints.tight(const Size(1, 1)))
+        ..paint(buffer, Offset.zero);
 
       // Unicode value should be U+2800 + 0x01 = 0x2801
       expect(buffer.getCell(0, 0)!.char, equals(String.fromCharCode(0x2801)));
@@ -167,13 +181,17 @@ void main() {
       // Clear and set bottom-right pixel (1, 3) -> Dot 8 (0x80)
       canvas.clear();
       canvas.setPixel(1, 3, true);
-      canvas.render(buffer, const Rect(0, 0, 1, 1));
+      ElementWidget(canvas)
+        ..layout(BoxConstraints.tight(const Size(1, 1)))
+        ..paint(buffer, Offset.zero);
       // Unicode value should be U+2800 + 0x80 = 0x2880 (⢀)
       expect(buffer.getCell(0, 0)!.char, equals(String.fromCharCode(0x2880)));
 
       // Set both: U+2881
       canvas.setPixel(0, 0, true);
-      canvas.render(buffer, const Rect(0, 0, 1, 1));
+      ElementWidget(canvas)
+        ..layout(BoxConstraints.tight(const Size(1, 1)))
+        ..paint(buffer, Offset.zero);
       expect(buffer.getCell(0, 0)!.char, equals(String.fromCharCode(0x2881)));
     });
 
@@ -181,7 +199,9 @@ void main() {
       final canvas = Canvas(6, 3); // 12x12 sub-pixels
       canvas.drawLine(0, 0, 10, 10);
       final buffer = Buffer.blank(6, 3);
-      canvas.render(buffer, const Rect(0, 0, 6, 3));
+      ElementWidget(canvas)
+        ..layout(BoxConstraints.tight(const Size(6, 3)))
+        ..paint(buffer, Offset.zero);
 
       var totalFlagged = 0;
       for (var y = 0; y < 3; y++) {
@@ -229,7 +249,9 @@ void main() {
       // Draw with anti-aliasing on cell (0, 0) only (2x4 sub-pixels)
       canvas.fillBox(0, 0, 2, 4, antiAliased: true);
       final buffer = Buffer.blank(2, 2);
-      canvas.render(buffer, const Rect(0, 0, 2, 2));
+      ElementWidget(canvas)
+        ..layout(BoxConstraints.tight(const Size(2, 2)))
+        ..paint(buffer, Offset.zero);
 
       // Cell (0, 0) is completely covered (8/8 sub-pixels).
       // So it should render as solid block '█' rather than Braille characters.
@@ -250,7 +272,9 @@ void main() {
       canvas.isOccluded = (col, row) => col == 1 && row == 1;
 
       final buffer = Buffer.blank(3, 3);
-      canvas.render(buffer, const Rect(0, 0, 3, 3));
+      ElementWidget(canvas)
+        ..layout(BoxConstraints.tight(const Size(3, 3)))
+        ..paint(buffer, Offset.zero);
 
       // Cell (1, 1) should be blank/empty because we skipped translation
       expect(buffer.getCell(1, 1)!.char, equals(' ')); // blank cell
@@ -264,7 +288,9 @@ void main() {
 
       // Draw a line colored from red to blue
       canvas.drawLineColored(0, 0, 4, 8, Colors.red, Colors.blue);
-      canvas.render(buffer, const Rect(0, 0, 3, 3));
+      ElementWidget(canvas)
+        ..layout(BoxConstraints.tight(const Size(3, 3)))
+        ..paint(buffer, Offset.zero);
 
       // The cell at (0, 0) should have a foreground color that is Red
       final cell0 = buffer.getCell(0, 0);
@@ -296,7 +322,9 @@ void main() {
         Colors.blue,
       );
       buffer.clear();
-      canvas.render(buffer, const Rect(0, 0, 3, 3));
+      ElementWidget(canvas)
+        ..layout(BoxConstraints.tight(const Size(3, 3)))
+        ..paint(buffer, Offset.zero);
 
       // Ensure some pixels are colored
       expect(buffer.getCell(0, 0)!.style.foreground, isNotNull);
@@ -318,7 +346,9 @@ void main() {
         Colors.green,
       );
       buffer.clear();
-      canvas.render(buffer, const Rect(0, 0, 3, 3));
+      ElementWidget(canvas)
+        ..layout(BoxConstraints.tight(const Size(3, 3)))
+        ..paint(buffer, Offset.zero);
 
       // Ensure some pixels are colored
       expect(buffer.getCell(0, 0)!.style.foreground, isNotNull);
@@ -337,7 +367,9 @@ void main() {
         8,
         cellStyle: const Style(foreground: Colors.green),
       );
-      canvas.render(buffer, const Rect(0, 0, 3, 3));
+      ElementWidget(canvas)
+        ..layout(BoxConstraints.tight(const Size(3, 3)))
+        ..paint(buffer, Offset.zero);
 
       // Cell at (0, 0) has the line pixel, should have green foreground and black background
       final cell0 = buffer.getCell(0, 0);
@@ -365,7 +397,9 @@ void main() {
         for (var i = 0; i < 100; i++) {
           canvas.setPixel((f + i) % 160, (f * 2 + i) % 96, true);
         }
-        canvas.render(buffer, const Rect(0, 0, 80, 24));
+        ElementWidget(canvas)
+          ..layout(BoxConstraints.tight(const Size(80, 24)))
+          ..paint(buffer, Offset.zero);
       }
 
       stopwatch.stop();
@@ -467,7 +501,9 @@ void main() {
           );
 
           final buffer = Buffer.blank(width, height);
-          canvas.render(buffer, Rect(0, 0, width, height));
+          ElementWidget(canvas)
+            ..layout(BoxConstraints.tight(Size(width, height)))
+            ..paint(buffer, Offset.zero);
 
           // Bounding box of the triangle
           final minX = t2px.reduce(min);
@@ -621,7 +657,9 @@ void main() {
       final buffer = Buffer.blank(5, 1);
 
       // When focused
-      area.render(buffer, const Rect(0, 0, 5, 1));
+      ElementWidget(area)
+        ..layout(BoxConstraints.tight(const Size(5, 1)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -633,7 +671,9 @@ void main() {
       // Reset buffer and set focused = false
       buffer.clear();
       area.focused = false;
-      area.render(buffer, const Rect(0, 0, 5, 1));
+      ElementWidget(area)
+        ..layout(BoxConstraints.tight(const Size(5, 1)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -661,7 +701,9 @@ void main() {
         buffer.clear();
 
         // 1. Empty state: showing placeholder
-        area.render(buffer, const Rect(0, 0, 10, 1));
+        ElementWidget(area)
+          ..layout(BoxConstraints.tight(const Size(10, 1)))
+          ..paint(buffer, Offset.zero);
         expect(
           buffer,
           matchesAnsiGolden(
@@ -673,7 +715,9 @@ void main() {
         // 2. Add text: placeholder should go away
         buffer.clear();
         area.handleKeyEvent(const KeyEvent('x', KeyType.character));
-        area.render(buffer, const Rect(0, 0, 10, 1));
+        ElementWidget(area)
+          ..layout(BoxConstraints.tight(const Size(10, 1)))
+          ..paint(buffer, Offset.zero);
         expect(
           buffer,
           matchesAnsiGolden(
@@ -685,7 +729,9 @@ void main() {
         // 3. Clear text: placeholder should reappear
         buffer.clear();
         area.handleKeyEvent(const KeyEvent('backspace', KeyType.backspace));
-        area.render(buffer, const Rect(0, 0, 10, 1));
+        ElementWidget(area)
+          ..layout(BoxConstraints.tight(const Size(10, 1)))
+          ..paint(buffer, Offset.zero);
         expect(
           buffer,
           matchesAnsiGolden(
@@ -705,7 +751,9 @@ void main() {
         separator: ' | ',
       );
 
-      help.render(buffer, const Rect(0, 0, 20, 2));
+      ElementWidget(help)
+        ..layout(BoxConstraints.tight(const Size(20, 2)))
+        ..paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -745,7 +793,9 @@ void main() {
         selectedRowIndex: 1,
       );
 
-      table.render(buffer, const Rect(0, 0, 15, 4));
+      ElementWidget(table)
+        ..layout(BoxConstraints.tight(const Size(15, 4)))
+        ..paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -768,7 +818,9 @@ void main() {
         separator: '-',
       );
 
-      paginator.render(buffer, const Rect(0, 0, 10, 1));
+      ElementWidget(paginator)
+        ..layout(BoxConstraints.tight(const Size(10, 1)))
+        ..paint(buffer, Offset.zero);
       expect(
         buffer,
         matchesAnsiGolden(
@@ -915,7 +967,9 @@ void main() {
 
       // 1. Focused case: f1 is focused by default, f2 is unfocused
       final buffer = Buffer(20, 10);
-      form.render(buffer, const Rect(0, 0, 20, 10));
+      ElementWidget(form)
+        ..layout(BoxConstraints.tight(const Size(20, 10)))
+        ..paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -929,7 +983,9 @@ void main() {
       f1.focused = false;
       f2.focused = false;
       final buffer2 = Buffer(20, 10);
-      form.render(buffer2, const Rect(0, 0, 20, 10));
+      ElementWidget(form)
+        ..layout(BoxConstraints.tight(const Size(20, 10)))
+        ..paint(buffer2, Offset.zero);
 
       expect(
         buffer2,
@@ -963,7 +1019,9 @@ void main() {
         easing: Easing.linear,
       );
       final bufferLinear = Buffer(12, 1);
-      barLinear.render(bufferLinear, const Rect(0, 0, 12, 1));
+      ElementWidget(barLinear)
+        ..layout(BoxConstraints.tight(const Size(12, 1)))
+        ..paint(bufferLinear, Offset.zero);
 
       var filledLinear = 0;
       for (var x = 0; x < 12; x++) {
@@ -980,7 +1038,9 @@ void main() {
         easing: Easing.easeInQuad,
       );
       final bufferEased = Buffer(12, 1);
-      barEased.render(bufferEased, const Rect(0, 0, 12, 1));
+      ElementWidget(barEased)
+        ..layout(BoxConstraints.tight(const Size(12, 1)))
+        ..paint(bufferEased, Offset.zero);
 
       var filledEased = 0;
       for (var x = 0; x < 12; x++) {
@@ -1014,7 +1074,9 @@ void main() {
       expect(tree.flatNodes.length, equals(4));
 
       final buffer = Buffer(25, 4);
-      tree.render(buffer, const Rect(0, 0, 25, 4));
+      ElementWidget(tree)
+        ..layout(BoxConstraints.tight(const Size(25, 4)))
+        ..paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -1078,7 +1140,9 @@ void main() {
       expect(tree.focused, isTrue);
 
       final bufferFocused = Buffer(10, 1);
-      tree.render(bufferFocused, const Rect(0, 0, 10, 1));
+      ElementWidget(tree)
+        ..layout(BoxConstraints.tight(const Size(10, 1)))
+        ..paint(bufferFocused, Offset.zero);
       expect(
         bufferFocused,
         matchesAnsiGolden(
@@ -1090,7 +1154,9 @@ void main() {
       // Set focused to false
       tree.focused = false;
       final bufferUnfocused = Buffer(10, 1);
-      tree.render(bufferUnfocused, const Rect(0, 0, 10, 1));
+      ElementWidget(tree)
+        ..layout(BoxConstraints.tight(const Size(10, 1)))
+        ..paint(bufferUnfocused, Offset.zero);
       expect(
         bufferUnfocused,
         matchesAnsiGolden(

--- a/packages/termui/test/prompt_runner_test.dart
+++ b/packages/termui/test/prompt_runner_test.dart
@@ -80,12 +80,24 @@ class TestKeyConsumerWidget extends Widget
   const TestKeyConsumerWidget({this.focused = true, this.shouldConsume = true});
 
   @override
-  void render(Buffer buffer, Rect area) {}
+  Element createElement() => _TestKeyConsumerElement(this);
 
   @override
   bool handleKeyEvent(ui.KeyEvent event) {
     return shouldConsume;
   }
+}
+
+class _TestKeyConsumerElement extends Element {
+  _TestKeyConsumerElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return constraints.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {}
 }
 
 void main() {

--- a/packages/termui/test/responsive_dashboard_test.dart
+++ b/packages/termui/test/responsive_dashboard_test.dart
@@ -9,10 +9,10 @@ void main() {
     final element = app.createElement()..mount(null);
 
     final buffer = Buffer.blank(80, 20);
-    expect(
-      () => element.render(buffer, const Rect(0, 0, 80, 20)),
-      returnsNormally,
-    );
+    expect(() {
+      element.layout(BoxConstraints.tight(const Size(80, 20)));
+      element.paint(buffer, Offset.zero);
+    }, returnsNormally);
 
     element.unmount(); // Clean up timers
   });
@@ -22,10 +22,10 @@ void main() {
     final element = app.createElement()..mount(null);
 
     final buffer = Buffer.blank(30, 8);
-    expect(
-      () => element.render(buffer, const Rect(0, 0, 30, 8)),
-      returnsNormally,
-    );
+    expect(() {
+      element.layout(BoxConstraints.tight(const Size(30, 8)));
+      element.paint(buffer, Offset.zero);
+    }, returnsNormally);
 
     // Verify it renders the fallback message: "Screen too small!"
     var foundFallbackText = false;
@@ -50,17 +50,17 @@ void main() {
 
     // Initial render
     final buffer1 = Buffer.blank(80, 20);
-    expect(
-      () => element.render(buffer1, const Rect(0, 0, 80, 20)),
-      returnsNormally,
-    );
+    expect(() {
+      element.layout(BoxConstraints.tight(const Size(80, 20)));
+      element.paint(buffer1, Offset.zero);
+    }, returnsNormally);
 
     // Simulate resize by rendering with a different bounding box
     final buffer2 = Buffer.blank(100, 30);
-    expect(
-      () => element.render(buffer2, const Rect(0, 0, 100, 30)),
-      returnsNormally,
-    );
+    expect(() {
+      element.layout(BoxConstraints.tight(const Size(100, 30)));
+      element.paint(buffer2, Offset.zero);
+    }, returnsNormally);
 
     element.unmount(); // Clean up timers
   });

--- a/packages/termui/test/responsive_dashboard_test.dart
+++ b/packages/termui/test/responsive_dashboard_test.dart
@@ -1,0 +1,67 @@
+import 'package:test/test.dart';
+import 'package:termui/ui/buffer.dart';
+import 'package:termui/ui/layout.dart';
+import '../example/03_responsive_dashboard.dart';
+
+void main() {
+  test('Responsive Dashboard layout tests - normal size', () {
+    const app = DashboardApp();
+    final element = app.createElement()..mount(null);
+
+    final buffer = Buffer.blank(80, 20);
+    expect(
+      () => element.render(buffer, const Rect(0, 0, 80, 20)),
+      returnsNormally,
+    );
+
+    element.unmount(); // Clean up timers
+  });
+
+  test('Responsive Dashboard layout tests - small size fallback', () {
+    const app = DashboardApp();
+    final element = app.createElement()..mount(null);
+
+    final buffer = Buffer.blank(30, 8);
+    expect(
+      () => element.render(buffer, const Rect(0, 0, 30, 8)),
+      returnsNormally,
+    );
+
+    // Verify it renders the fallback message: "Screen too small!"
+    var foundFallbackText = false;
+    for (var y = 0; y < buffer.height; y++) {
+      final sb = StringBuffer();
+      for (var x = 0; x < buffer.width; x++) {
+        sb.write(buffer.getCell(x, y)?.char ?? ' ');
+      }
+      if (sb.toString().contains('Screen too small!')) {
+        foundFallbackText = true;
+        break;
+      }
+    }
+    expect(foundFallbackText, isTrue);
+
+    element.unmount(); // Clean up timers
+  });
+
+  test('Responsive Dashboard layout tests - resize dynamic redistribution', () {
+    const app = DashboardApp();
+    final element = app.createElement()..mount(null);
+
+    // Initial render
+    final buffer1 = Buffer.blank(80, 20);
+    expect(
+      () => element.render(buffer1, const Rect(0, 0, 80, 20)),
+      returnsNormally,
+    );
+
+    // Simulate resize by rendering with a different bounding box
+    final buffer2 = Buffer.blank(100, 30);
+    expect(
+      () => element.render(buffer2, const Rect(0, 0, 100, 30)),
+      returnsNormally,
+    );
+
+    element.unmount(); // Clean up timers
+  });
+}

--- a/packages/termui/test/rich_text_span_test.dart
+++ b/packages/termui/test/rich_text_span_test.dart
@@ -71,7 +71,9 @@ void main() {
         wrap: false,
         textAlign: TextAlign.center,
       );
-      centerRich.render(buffer, const Rect(0, 0, 10, 1));
+      ElementWidget(centerRich)
+        ..layout(BoxConstraints.tight(const Size(10, 1)))
+        ..paint(buffer, Offset.zero);
 
       // 'abc' centered in 10 width -> startX = (10 - 3) ~/ 2 = 3.
       // Cells 3-5: 'abc'
@@ -86,7 +88,9 @@ void main() {
         textAlign: TextAlign.right,
       );
       final viewport = Viewport(buffer, const Rect(0, 1, 10, 1));
-      rightRich.render(viewport, const Rect(0, 0, 10, 1));
+      ElementWidget(rightRich)
+        ..layout(BoxConstraints.tight(const Size(10, 1)))
+        ..paint(viewport, Offset.zero);
 
       // 'xyz' right-aligned in 10 width -> startX = 10 - 3 = 7.
       // Cells 7-9: 'xyz' on line 1

--- a/packages/termui/test/rich_text_test.dart
+++ b/packages/termui/test/rich_text_test.dart
@@ -30,7 +30,9 @@ void main() {
         ),
       );
 
-      label.render(buffer, const Rect(0, 0, 10, 1));
+      ElementWidget(label)
+        ..layout(BoxConstraints.tight(const Size(10, 1)))
+        ..paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -67,7 +69,9 @@ void main() {
       // 'rich' (4) + ' ' -> fits (total 10)
       // 'world' (5) -> wraps to line 1
       // 'wrapping' (8) -> wraps to line 2
-      paragraph.render(buffer, const Rect(0, 0, 10, 3));
+      ElementWidget(paragraph)
+        ..layout(BoxConstraints.tight(const Size(10, 3)))
+        ..paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -107,7 +111,9 @@ void main() {
       );
       final buffer = Buffer.blank(10, 2);
 
-      timer.render(buffer, const Rect(0, 0, 10, 2));
+      ElementWidget(timer)
+        ..layout(BoxConstraints.tight(const Size(10, 2)))
+        ..paint(buffer, Offset.zero);
 
       expect(
         buffer,

--- a/packages/termui/test/scratch_debug.dart
+++ b/packages/termui/test/scratch_debug.dart
@@ -23,18 +23,24 @@ void main() {
       .clear(); // <--- Clear first to make initial state match cleared state style
 
   // 1. Empty state: showing placeholder
-  area.render(buffer, const Rect(0, 0, 10, 1));
+  ElementWidget(area)
+    ..layout(BoxConstraints.tight(const Size(10, 1)))
+    ..paint(buffer, Offset.zero);
   final ansi1 = AnsiScreenshot.capture(buffer);
 
   // 2. Add text
   buffer.clear();
   area.handleKeyEvent(const KeyEvent('x', KeyType.character));
-  area.render(buffer, const Rect(0, 0, 10, 1));
+  ElementWidget(area)
+    ..layout(BoxConstraints.tight(const Size(10, 1)))
+    ..paint(buffer, Offset.zero);
 
   // 3. Clear text
   buffer.clear();
   area.handleKeyEvent(const KeyEvent('backspace', KeyType.backspace));
-  area.render(buffer, const Rect(0, 0, 10, 1));
+  ElementWidget(area)
+    ..layout(BoxConstraints.tight(const Size(10, 1)))
+    ..paint(buffer, Offset.zero);
   final ansi3 = AnsiScreenshot.capture(buffer);
 
   print('ansi1 length: ${ansi1.length}');

--- a/packages/termui/test/widgets_spec_test.dart
+++ b/packages/termui/test/widgets_spec_test.dart
@@ -8,16 +8,42 @@ import 'package:termui_recorder/termui_recorder.dart';
 
 class SpyWidget extends Widget {
   int renderCount = 0;
+
   @override
-  void render(Buffer buffer, Rect area) {
-    renderCount++;
+  Element createElement() => _SpyElement(this);
+}
+
+class _SpyElement extends Element {
+  _SpyElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return constraints.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    (widget as SpyWidget).renderCount++;
   }
 }
 
 class DummyWidget extends Widget {
   const DummyWidget();
+
   @override
-  void render(Buffer buffer, Rect area) {}
+  Element createElement() => _DummyElement(this);
+}
+
+class _DummyElement extends Element {
+  _DummyElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return constraints.constrain(Size.zero);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {}
 }
 
 void main() {
@@ -33,7 +59,9 @@ void main() {
       );
 
       final buffer = Buffer.blank(21, 5);
-      splitPane.render(buffer, const Rect(0, 0, 21, 5));
+      ElementWidget(splitPane)
+        ..layout(BoxConstraints.tight(const Size(21, 5)))
+        ..paint(buffer, Offset.zero);
 
       // 50% of 21 is round(10.5) = 11.
       // So divider is drawn at x = 11.
@@ -54,7 +82,9 @@ void main() {
       );
 
       final buffer = Buffer.blank(21, 5);
-      splitPane.render(buffer, const Rect(0, 0, 21, 5));
+      ElementWidget(splitPane)
+        ..layout(BoxConstraints.tight(const Size(21, 5)))
+        ..paint(buffer, Offset.zero);
 
       expect(
         buffer,
@@ -78,13 +108,13 @@ void main() {
         );
 
         final buffer = Buffer.blank(21, 5);
-        splitPane.render(
-          buffer,
-          const Rect(0, 0, 21, 5),
-        ); // Resolves dividerX to 11
+        final splitPaneWrapper = ElementWidget(splitPane);
+        splitPaneWrapper.layout(BoxConstraints.tight(const Size(21, 5)));
+        splitPaneWrapper.paint(buffer, Offset.zero);
+        final splitPaneEl = splitPaneWrapper.element as SplitPaneElement;
 
         // Inject press sequence at divider (11)
-        splitPane.handleMouseEvent(
+        splitPaneEl.handleMouseEvent(
           const MouseEvent(
             x: 12,
             y: 1,
@@ -96,7 +126,7 @@ void main() {
         );
 
         // Drag left by 5 columns (to 6)
-        splitPane.handleMouseEvent(
+        splitPaneEl.handleMouseEvent(
           const MouseEvent(
             x: 7,
             y: 1,
@@ -130,13 +160,13 @@ void main() {
       );
 
       final buffer = Buffer.blank(21, 5);
-      splitPane.render(
-        buffer,
-        const Rect(0, 0, 21, 5),
-      ); // Initial ratio is min = 8
+      final splitPaneWrapper = ElementWidget(splitPane);
+      splitPaneWrapper.layout(BoxConstraints.tight(const Size(21, 5)));
+      splitPaneWrapper.paint(buffer, Offset.zero);
+      final splitPaneEl = splitPaneWrapper.element as SplitPaneElement;
 
       // Press at divider (8)
-      splitPane.handleMouseEvent(
+      splitPaneEl.handleMouseEvent(
         const MouseEvent(
           x: 9,
           y: 1,
@@ -148,7 +178,7 @@ void main() {
       );
 
       // Attempt to drag past child1's min limit (8) to 5
-      splitPane.handleMouseEvent(
+      splitPaneEl.handleMouseEvent(
         const MouseEvent(
           x: 6,
           y: 1,
@@ -179,7 +209,9 @@ void main() {
       );
 
       final buffer = Buffer.blank(20, 50);
-      lazyTable.render(buffer, const Rect(0, 0, 20, 50));
+      ElementWidget(lazyTable)
+        ..layout(BoxConstraints.tight(const Size(20, 50)))
+        ..paint(buffer, Offset.zero);
 
       expect(builderCalls, equals(50));
     });
@@ -199,7 +231,9 @@ void main() {
       final buffer = Buffer.blank(20, 50);
 
       // Initial render at scrollOffset = 0
-      lazyTable.render(buffer, const Rect(0, 0, 20, 50));
+      ElementWidget(lazyTable)
+        ..layout(BoxConstraints.tight(const Size(20, 50)))
+        ..paint(buffer, Offset.zero);
       expect(queriedIndices.first, equals(0));
       expect(queriedIndices.last, equals(49));
 
@@ -208,7 +242,9 @@ void main() {
       // Scroll down by 1
       lazyTable.scrollOffset = 1;
       lazyTable.selectedRowIndex = 1;
-      lazyTable.render(buffer, const Rect(0, 0, 20, 50));
+      ElementWidget(lazyTable)
+        ..layout(BoxConstraints.tight(const Size(20, 50)))
+        ..paint(buffer, Offset.zero);
 
       // Index 0 must be dropped (not queried), and index 50 must be queried
       expect(queriedIndices.contains(0), isFalse);
@@ -234,7 +270,9 @@ void main() {
       );
 
       final buffer = Buffer.blank(1, 10);
-      scrollBar.render(buffer, const Rect(0, 0, 1, 10));
+      ElementWidget(scrollBar)
+        ..layout(BoxConstraints.tight(const Size(1, 10)))
+        ..paint(buffer, Offset.zero);
 
       // Assert only 1 cell contains the thumb char '█'
       var thumbCount = 0;
@@ -258,11 +296,9 @@ void main() {
       );
 
       final buffer = Buffer.blank(1, 10);
-      scrollBar.render(
-        buffer,
-        const Rect(0, 0, 1, 10),
-      ); // Resolves area height to 10
-
+      final scrollBarWrapper = ElementWidget(scrollBar);
+      scrollBarWrapper.layout(BoxConstraints.tight(const Size(1, 10)));
+      scrollBarWrapper.paint(buffer, Offset.zero);
       // Click at y = 5 (which is 50% of track height 10)
       scrollBar.handleMouseEvent(
         const MouseEvent(
@@ -290,8 +326,9 @@ void main() {
       );
 
       final buffer = Buffer.blank(1, 10);
-      scrollBar.render(buffer, const Rect(0, 0, 1, 10));
-
+      final scrollBarWrapper = ElementWidget(scrollBar);
+      scrollBarWrapper.layout(BoxConstraints.tight(const Size(1, 10)));
+      scrollBarWrapper.paint(buffer, Offset.zero);
       // Drag past top (y = -5)
       scrollBar.handleMouseEvent(
         const MouseEvent(
@@ -339,7 +376,9 @@ void main() {
       );
 
       final buffer = Buffer.blank(10, 5);
-      panel.render(buffer, const Rect(0, 0, 10, 5));
+      ElementWidget(panel)
+        ..layout(BoxConstraints.tight(const Size(10, 5)))
+        ..paint(buffer, Offset.zero);
 
       expect(spy1.renderCount, equals(1));
       expect(spy2.renderCount, equals(0));

--- a/packages/termui_flutter/README.md
+++ b/packages/termui_flutter/README.md
@@ -99,7 +99,9 @@ class MyApp extends StatelessWidget {
                   ]);
 
                   // Draw layout to buffer
-                  layout.render(buffer, termui.Rect(0, 0, termSize.x, termSize.y));
+                  final elementWrapper = termui.ElementWidget(layout);
+                  elementWrapper.layout(termui.BoxConstraints.tight(termui.Size(termSize.x, termSize.y)));
+                  elementWrapper.paint(buffer, termui.Offset.zero);
                   // Flush buffer to the Flutter painter
                   drawFrame(buffer);
                 }

--- a/packages/termui_flutter/example/lib/scenario_a_demo.dart
+++ b/packages/termui_flutter/example/lib/scenario_a_demo.dart
@@ -57,7 +57,9 @@ Future<void> runScenarioADemo(
       ),
     ]);
 
-    layout.render(screenBuffer, Rect(0, 0, width, height));
+    final elementWrapper = ElementWidget(layout);
+    elementWrapper.layout(BoxConstraints.tight(Size(width, height)));
+    elementWrapper.paint(screenBuffer, Offset.zero);
 
     if (onFrameRedrawn != null) {
       onFrameRedrawn(screenBuffer);

--- a/packages/termui_flutter/example/lib/window_manager_interactive_demo.dart
+++ b/packages/termui_flutter/example/lib/window_manager_interactive_demo.dart
@@ -186,7 +186,9 @@ Future<void> runWindowManagerInteractive(
       ..sort((a, b) => a.zIndex.compareTo(b.zIndex));
 
     for (final win in sortedWins) {
-      win.render(screenBuffer, Rect(0, 0, width, height));
+      final winElement = win.createElement()..mount(null);
+      winElement.layout(BoxConstraints.tight(Size(width, height)));
+      winElement.paint(screenBuffer, Offset.zero);
     }
 
     // Top status bar

--- a/packages/termui_shared_examples/lib/custom_widgets/gauge.dart
+++ b/packages/termui_shared_examples/lib/custom_widgets/gauge.dart
@@ -24,20 +24,37 @@ class Gauge extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0) return;
+  Element createElement() => _GaugeElement(this);
+}
 
-    final percent = ((value - min) / (max - min)).clamp(0.0, 1.0);
-    final width = area.width;
-    final needlePos = (percent * (width - 1)).round();
+class _GaugeElement extends Element {
+  _GaugeElement(super.widget);
 
-    for (int i = 0; i < width; i++) {
-      final posPercent = i / (width - 1 > 0 ? width - 1 : 1);
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
 
-      Color activeColor = thresholds.isNotEmpty
-          ? thresholds.first.$2
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = size.width;
+    final h = size.height;
+    if (w <= 0 || h <= 0) return;
+    final gauge = widget as Gauge;
+
+    final percent = ((gauge.value - gauge.min) / (gauge.max - gauge.min)).clamp(
+      0.0,
+      1.0,
+    );
+    final needlePos = (percent * (w - 1)).round();
+
+    for (int i = 0; i < w; i++) {
+      final posPercent = i / (w - 1 > 0 ? w - 1 : 1);
+
+      Color activeColor = gauge.thresholds.isNotEmpty
+          ? gauge.thresholds.first.$2
           : Colors.white;
-      for (final threshold in thresholds) {
+      for (final threshold in gauge.thresholds) {
         if (posPercent >= threshold.$1) {
           activeColor = threshold.$2;
         }
@@ -46,22 +63,22 @@ class Gauge extends Widget {
       final style = Style(foreground: activeColor);
 
       if (i == needlePos) {
-        if (area.height > 1) {
+        if (h > 1) {
           buffer.writeString(
-            i,
-            0,
+            offset.dx + i,
+            offset.dy,
             '▼',
             style.merge(const Style(modifiers: Modifier.bold)),
           );
-          buffer.writeString(i, 1, '█', style);
+          buffer.writeString(offset.dx + i, offset.dy + 1, '█', style);
         } else {
-          buffer.writeString(i, 0, '█', style);
+          buffer.writeString(offset.dx + i, offset.dy, '█', style);
         }
       } else {
-        if (area.height > 1) {
-          buffer.writeString(i, 1, '▒', style);
+        if (h > 1) {
+          buffer.writeString(offset.dx + i, offset.dy + 1, '▒', style);
         } else {
-          buffer.writeString(i, 0, '▒', style);
+          buffer.writeString(offset.dx + i, offset.dy, '▒', style);
         }
       }
     }

--- a/packages/termui_shared_examples/lib/custom_widgets/radar.dart
+++ b/packages/termui_shared_examples/lib/custom_widgets/radar.dart
@@ -39,37 +39,64 @@ class Radar extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    if (area.width <= 0 || area.height <= 0) return;
+  Element createElement() => _RadarElement(this);
+}
+
+class _RadarElement extends Element {
+  _RadarElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = size.width;
+    final h = size.height;
+    if (w <= 0 || h <= 0) return;
+    final rWidget = widget as Radar;
 
     // Use a Canvas to draw the radar
-    final canvas = Canvas(area.width, area.height);
+    final canvas = Canvas(w, h);
 
     // Calculate center in sub-pixel coordinates
-    final cx = area.width; // area.width * 2 / 2
-    final cy = area.height * 2; // area.height * 4 / 2
+    final cx = w; // area.width * 2 / 2
+    final cy = h * 2; // area.height * 4 / 2
 
     final radius = min(cx, cy) - 1;
 
     if (radius > 0) {
       // Draw outer circle
-      canvas.drawCircle(cx, cy, radius, cellStyle: gridStyle);
+      canvas.drawCircle(cx, cy, radius, cellStyle: rWidget.gridStyle);
 
       // Draw inner circles
-      canvas.drawCircle(cx, cy, radius ~/ 2, cellStyle: gridStyle);
-      canvas.drawCircle(cx, cy, radius ~/ 4, cellStyle: gridStyle);
+      canvas.drawCircle(cx, cy, radius ~/ 2, cellStyle: rWidget.gridStyle);
+      canvas.drawCircle(cx, cy, radius ~/ 4, cellStyle: rWidget.gridStyle);
 
       // Draw crosshairs
-      canvas.drawLine(cx - radius, cy, cx + radius, cy, cellStyle: gridStyle);
-      canvas.drawLine(cx, cy - radius, cx, cy + radius, cellStyle: gridStyle);
+      canvas.drawLine(
+        cx - radius,
+        cy,
+        cx + radius,
+        cy,
+        cellStyle: rWidget.gridStyle,
+      );
+      canvas.drawLine(
+        cx,
+        cy - radius,
+        cx,
+        cy + radius,
+        cellStyle: rWidget.gridStyle,
+      );
 
       // Draw scanner arm
-      final armX = cx + (cos(scannerAngle) * radius).round();
-      final armY = cy + (sin(scannerAngle) * radius).round();
+      final armX = cx + (cos(rWidget.scannerAngle) * radius).round();
+      final armY = cy + (sin(rWidget.scannerAngle) * radius).round();
       canvas.drawLineColored(cx, cy, armX, armY, Colors.white, Colors.green);
 
       // Draw blips
-      for (final blip in blips) {
+      for (final blip in rWidget.blips) {
         final blipR = blip.distance * radius;
         final blipX = cx + (cos(blip.angle) * blipR).round();
         final blipY = cy + (sin(blip.angle) * blipR).round();
@@ -85,6 +112,9 @@ class Radar extends Widget {
     }
 
     // Render the canvas onto the buffer
-    canvas.render(buffer, area);
+    final canvasEl = canvas.createElement()..mount(null);
+    canvasEl.layout(BoxConstraints.tight(Size(w, h)));
+    canvasEl.paint(buffer, offset);
+    canvasEl.unmount();
   }
 }

--- a/packages/termui_shared_examples/lib/widget_book/animations.dart
+++ b/packages/termui_shared_examples/lib/widget_book/animations.dart
@@ -323,18 +323,35 @@ class _SparkleButtonRenderWidget extends Widget {
   const _SparkleButtonRenderWidget(this.state);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final W = area.width;
-    final H = area.height;
-    state._lastWidth = W;
-    state._lastHeight = H;
+  Element createElement() => _SparkleButtonRenderElement(this);
+}
+
+class _SparkleButtonRenderElement extends Element {
+  _SparkleButtonRenderElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final W = size.width;
+    final H = size.height;
+    final wWidget = widget as _SparkleButtonRenderWidget;
+    wWidget.state._lastWidth = W;
+    wWidget.state._lastHeight = H;
 
     if (W <= 0 || H <= 0) return;
 
     // Clear transparent
     for (var y = 0; y < H; y++) {
       for (var x = 0; x < W; x++) {
-        buffer.setCell(x, y, Cell(' ', Style.transparent));
+        buffer.setCell(
+          offset.dx + x,
+          offset.dy + y,
+          Cell(' ', Style.transparent),
+        );
       }
     }
 
@@ -344,16 +361,24 @@ class _SparkleButtonRenderWidget extends Widget {
     final int bodyHeight = H - 1;
 
     // Draw shadow if hovering
-    if (state._isHovered && !state._isPressed) {
+    if (wWidget.state._isHovered && !wWidget.state._isPressed) {
       final shadowStyle = const Style(
         foreground: Color(64, 64, 64),
         modifiers: Modifier.dim,
       );
       for (var y = 1; y < H - 1; y++) {
-        buffer.setCell(W - 1, y, Cell('▐', shadowStyle));
+        buffer.setCell(
+          offset.dx + W - 1,
+          offset.dy + y,
+          Cell('▐', shadowStyle),
+        );
       }
       for (var x = 1; x < W; x++) {
-        buffer.setCell(x, H - 1, Cell('▄', shadowStyle));
+        buffer.setCell(
+          offset.dx + x,
+          offset.dy + H - 1,
+          Cell('▄', shadowStyle),
+        );
       }
     }
 
@@ -361,25 +386,29 @@ class _SparkleButtonRenderWidget extends Widget {
     // Draw body background
     for (var y = 0; y < bodyHeight; y++) {
       for (var x = 0; x < bodyWidth; x++) {
-        buffer.setCell(x, y, Cell(' ', baseStyle));
+        buffer.setCell(offset.dx + x, offset.dy + y, Cell(' ', baseStyle));
       }
     }
 
     // Write text
-    final textLen = state.widget.text.characters.length;
+    final textLen = wWidget.state.widget.text.characters.length;
     final startX = max(0, (bodyWidth - textLen) ~/ 2);
     final startY = max(0, (bodyHeight - 1) ~/ 2);
     buffer.writeString(
-      startX,
-      startY,
-      state.widget.text,
+      offset.dx + startX,
+      offset.dy + startY,
+      wWidget.state.widget.text,
       const Style(
         foreground: Colors.white,
         modifiers: Modifier.bold,
       ).merge(baseStyle),
     );
 
-    state.paintEffects(buffer, Rect(0, 0, bodyWidth, bodyHeight), baseStyle);
+    final v = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, bodyWidth, bodyHeight),
+    );
+    wWidget.state.paintEffects(v, Rect(0, 0, bodyWidth, bodyHeight), baseStyle);
   }
 }
 
@@ -484,18 +513,35 @@ class _FlashButtonRenderWidget extends Widget {
   const _FlashButtonRenderWidget(this.state);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final W = area.width;
-    final H = area.height;
-    state._lastWidth = W;
-    state._lastHeight = H;
+  Element createElement() => _FlashButtonRenderElement(this);
+}
+
+class _FlashButtonRenderElement extends Element {
+  _FlashButtonRenderElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final W = size.width;
+    final H = size.height;
+    final wWidget = widget as _FlashButtonRenderWidget;
+    wWidget.state._lastWidth = W;
+    wWidget.state._lastHeight = H;
 
     if (W <= 0 || H <= 0) return;
 
     // Clear transparent
     for (var y = 0; y < H; y++) {
       for (var x = 0; x < W; x++) {
-        buffer.setCell(x, y, Cell(' ', Style.transparent));
+        buffer.setCell(
+          offset.dx + x,
+          offset.dy + y,
+          Cell(' ', Style.transparent),
+        );
       }
     }
 
@@ -505,16 +551,24 @@ class _FlashButtonRenderWidget extends Widget {
     final int bodyHeight = H - 1;
 
     // Draw shadow if hovering
-    if (state._isHovered && !state._isPressed) {
+    if (wWidget.state._isHovered && !wWidget.state._isPressed) {
       final shadowStyle = const Style(
         foreground: Color(64, 64, 64),
         modifiers: Modifier.dim,
       );
       for (var y = 1; y < H - 1; y++) {
-        buffer.setCell(W - 1, y, Cell('▐', shadowStyle));
+        buffer.setCell(
+          offset.dx + W - 1,
+          offset.dy + y,
+          Cell('▐', shadowStyle),
+        );
       }
       for (var x = 1; x < W; x++) {
-        buffer.setCell(x, H - 1, Cell('▄', shadowStyle));
+        buffer.setCell(
+          offset.dx + x,
+          offset.dy + H - 1,
+          Cell('▄', shadowStyle),
+        );
       }
     }
 
@@ -522,24 +576,28 @@ class _FlashButtonRenderWidget extends Widget {
     // Draw body background
     for (var y = 0; y < bodyHeight; y++) {
       for (var x = 0; x < bodyWidth; x++) {
-        buffer.setCell(x, y, Cell(' ', baseStyle));
+        buffer.setCell(offset.dx + x, offset.dy + y, Cell(' ', baseStyle));
       }
     }
 
     // Write text
-    final textLen = state.widget.text.characters.length;
+    final textLen = wWidget.state.widget.text.characters.length;
     final startX = max(0, (bodyWidth - textLen) ~/ 2);
     final startY = max(0, (bodyHeight - 1) ~/ 2);
     buffer.writeString(
-      startX,
-      startY,
-      state.widget.text,
+      offset.dx + startX,
+      offset.dy + startY,
+      wWidget.state.widget.text,
       const Style(
         foreground: Colors.white,
         modifiers: Modifier.bold,
       ).merge(baseStyle),
     );
 
-    state.paintEffects(buffer, Rect(0, 0, bodyWidth, bodyHeight), baseStyle);
+    final v = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, bodyWidth, bodyHeight),
+    );
+    wWidget.state.paintEffects(v, Rect(0, 0, bodyWidth, bodyHeight), baseStyle);
   }
 }

--- a/packages/termui_shared_examples/lib/widget_book/layout_state.dart
+++ b/packages/termui_shared_examples/lib/widget_book/layout_state.dart
@@ -219,9 +219,22 @@ class VerticalDivider extends Widget {
   const VerticalDivider({this.style = Style.empty});
 
   @override
-  void render(Buffer buffer, Rect area) {
-    for (var y = 0; y < area.height; y++) {
-      buffer.setCell(0, y, Cell('│', style));
+  Element createElement() => _VerticalDividerElement(this);
+}
+
+class _VerticalDividerElement extends Element {
+  _VerticalDividerElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(1, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final vWidget = widget as VerticalDivider;
+    for (var y = 0; y < size.height; y++) {
+      buffer.setCell(offset.dx, offset.dy + y, Cell('│', vWidget.style));
     }
   }
 }

--- a/packages/termui_shared_examples/lib/widget_book/modal_dialog.dart
+++ b/packages/termui_shared_examples/lib/widget_book/modal_dialog.dart
@@ -146,7 +146,10 @@ class ModalDialogExample extends WidgetBookExample {
         ),
       ]),
     );
-    modal.render(buffer, Rect(0, 0, width, height));
+    final modalEl = modal.createElement()..mount(null);
+    modalEl.layout(BoxConstraints.tight(Size(width, height)));
+    modalEl.paint(buffer, Offset.zero);
+    modalEl.unmount();
   }
 
   @override

--- a/packages/termui_shared_examples/lib/widget_book/scenario_a.dart
+++ b/packages/termui_shared_examples/lib/widget_book/scenario_a.dart
@@ -17,16 +17,38 @@ class WindowManagerWidget extends Widget {
   WindowManagerWidget(this.windowManager);
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Element createElement() => _WindowManagerElement(this);
+}
+
+class _WindowManagerElement extends Element {
+  _WindowManagerElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = widget as WindowManagerWidget;
+    final localBuffer = Viewport(
+      buffer,
+      Rect(offset.dx, offset.dy, size.width, size.height),
+    );
     // Fill background with a dark mesh pattern
-    buffer.fill(Cell('░', const Style(foreground: Color(45, 45, 45))));
+    localBuffer.fill(Cell('░', const Style(foreground: Color(45, 45, 45))));
 
     // Sort windows by Z-Index to render bottom-to-top
-    final sortedWins = List<Window>.from(windowManager.windows)
+    final sortedWins = List<Window>.from(w.windowManager.windows)
       ..sort((a, b) => a.zIndex.compareTo(b.zIndex));
 
     for (final win in sortedWins) {
-      win.render(buffer, area);
+      final winEl = win.createElement()..mount(null);
+      winEl.layout(
+        BoxConstraints.tight(Size(localBuffer.width, localBuffer.height)),
+      );
+      winEl.paint(localBuffer, Offset.zero);
+      winEl.unmount();
     }
   }
 }

--- a/packages/termui_shared_examples/lib/widget_book/split_pane.dart
+++ b/packages/termui_shared_examples/lib/widget_book/split_pane.dart
@@ -11,11 +11,11 @@ import 'example_base.dart';
 /// (percentage or length) in real-time based on mouse interactions.
 class SplitPaneExample extends WidgetBookExample {
   /// The interactive split pane layout.
-  late final SplitPane splitPaneDemo;
+  late final ElementWidget splitPaneWrapper;
 
   @override
   void init() {
-    splitPaneDemo = SplitPane(
+    final splitPaneDemo = SplitPane(
       child1: Text(
         'Left Panel. Drag the │ divider in the middle with your mouse! Try resizing the window or dragging past the limit of 5 columns.',
         style: const Style(foreground: CharmColors.uni),
@@ -27,6 +27,7 @@ class SplitPaneExample extends WidgetBookExample {
       ),
       constraint2: const PercentageConstraint(50),
     );
+    splitPaneWrapper = ElementWidget(splitPaneDemo);
   }
 
   @override
@@ -35,7 +36,7 @@ class SplitPaneExample extends WidgetBookExample {
     required int width,
     required int height,
   }) {
-    return splitPaneDemo;
+    return splitPaneWrapper;
   }
 
   @override
@@ -46,7 +47,26 @@ class SplitPaneExample extends WidgetBookExample {
     int width,
     int height,
   ) {
-    splitPaneDemo.handleMouseEvent(event, localX, localY);
+    final el = splitPaneWrapper.element;
+    if (el is SplitPaneElement) {
+      final split = el.widget as SplitPane;
+      final lastArea = split.lastArea;
+      if (lastArea != null) {
+        final splitX = event.x - lastArea.x;
+        final splitY = event.y - lastArea.y;
+        el.handleMouseEvent(event, splitX, splitY);
+      }
+    }
+  }
+
+  @override
+  bool get capturesMouse {
+    final el = splitPaneWrapper.element;
+    if (el is SplitPaneElement) {
+      final split = el.widget as SplitPane;
+      return split.isDragging;
+    }
+    return false;
   }
 
   @override

--- a/packages/termui_shared_examples/lib/widget_book/widget_book_runner.dart
+++ b/packages/termui_shared_examples/lib/widget_book/widget_book_runner.dart
@@ -109,6 +109,8 @@ Future<void> runWidgetBookShared(
   var statusMessage = '';
   Timer? statusClearTimer;
 
+  Element? rootElement;
+
   void setStatus(String msg) {
     statusMessage = msg;
     statusClearTimer?.cancel();
@@ -181,7 +183,7 @@ Future<void> runWidgetBookShared(
         lastFpsMs = currentMs;
       }
 
-      _drawFrame(
+      rootElement = _drawFrame(
         terminal: terminal,
         buffer: buffer,
         renderer: renderer,
@@ -197,6 +199,7 @@ Future<void> runWidgetBookShared(
         platform: platform,
         isRecordingCast: isRecordingCast,
         statusMessage: statusMessage,
+        rootElement: rootElement,
       );
 
       if (isRecordingCast && castRecorder != null) {
@@ -402,6 +405,7 @@ Future<void> runWidgetBookShared(
     platform.stopTicker();
     sizeSubscription.cancel();
     statusClearTimer?.cancel();
+    rootElement?.unmount();
 
     if (isRecordingCast && castOutput != null) {
       final timestamp = DateTime.now().millisecondsSinceEpoch;
@@ -420,7 +424,7 @@ Future<void> runWidgetBookShared(
   }
 }
 
-void _drawFrame({
+Element? _drawFrame({
   required term.Terminal terminal,
   required Buffer buffer,
   required Renderer renderer,
@@ -436,6 +440,7 @@ void _drawFrame({
   required WidgetBookPlatform platform,
   bool isRecordingCast = false,
   String statusMessage = '',
+  Element? rootElement,
 }) {
   buffer.clear();
 
@@ -548,7 +553,15 @@ void _drawFrame({
   Tracer.record(_traceFrameBuildId, Phase.end);
 
   Tracer.record(_traceFrameRenderId, Phase.begin);
-  appLayout.render(buffer, Rect(0, 0, width, height));
+  final Element currentRootElement;
+  if (rootElement == null) {
+    currentRootElement = appLayout.createElement()..mount(null);
+  } else {
+    currentRootElement = rootElement;
+    currentRootElement.update(appLayout);
+  }
+  currentRootElement.layout(BoxConstraints.tight(Size(width, height)));
+  currentRootElement.paint(buffer, Offset.zero);
 
   if (showModalDemo) {
     activeExample.renderOverlay(buffer, width, height);
@@ -649,6 +662,7 @@ void _drawFrame({
     }
   }
   Tracer.record(_traceFrameOutputId, Phase.end);
+  return currentRootElement;
 }
 
 String _getHeaderText({

--- a/packages/termui_shared_examples/lib/window_manager_demo/scenario_a_widgets.dart
+++ b/packages/termui_shared_examples/lib/window_manager_demo/scenario_a_widgets.dart
@@ -20,10 +20,24 @@ class SystemDiagnosticsWidget extends Widget {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final w = area.width;
-    final h = area.height;
+  Element createElement() => _SystemDiagnosticsElement(this);
+}
+
+class _SystemDiagnosticsElement extends Element {
+  _SystemDiagnosticsElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = size.width;
+    final h = size.height;
     if (w <= 0 || h <= 0) return;
+    final target = widget as SystemDiagnosticsWidget;
+    final tickCount = target.tickCount;
 
     final table = Table(
       headers: ['PID', 'Process', 'CPU%', 'Mem'],
@@ -49,23 +63,28 @@ class SystemDiagnosticsWidget extends Widget {
           '76MB',
         ],
       ],
-      selectedRowStyle: const Style(
-        foreground: Colors.white,
-        background: Colors.orange,
-        modifiers: Modifier.bold,
-      ),
     );
 
-    final progressCols = (w - 2 > 0) ? ((w - 2) * progress).round() : 0;
-    final remainingCols = max(0, w - 2 - progressCols);
-    final progressBar = '[${'█' * progressCols}${'░' * remainingCols}]';
+    // Render title block
+    final totalCpu =
+        19.5 + sin(tickCount * 0.1) * 3 + cos(tickCount * 0.05) * 0.5;
+    final progressBarWidth = (w - 18).clamp(5, 40);
+    final filledWidth = (progressBarWidth * (totalCpu / 100)).round().clamp(
+      0,
+      progressBarWidth,
+    );
+    final progressBar =
+        '[${'█' * filledWidth}${'░' * (progressBarWidth - filledWidth)}]';
 
     final col = Column([
       SizedBox(
         height: 1,
         child: Text(
-          'CPU Task Sync Progress:',
-          style: const Style(modifiers: Modifier.bold),
+          ' SYSTEM MONITOR - CPU: ${totalCpu.toStringAsFixed(1)}%',
+          style: const Style(
+            foreground: Color(0, 255, 0),
+            modifiers: Modifier.bold,
+          ),
         ),
       ),
       SizedBox(
@@ -79,7 +98,10 @@ class SystemDiagnosticsWidget extends Widget {
       Expanded(child: table),
     ]);
 
-    col.render(buffer, Rect(0, 0, w, h));
+    final colEl = col.createElement()..mount(null);
+    colEl.layout(BoxConstraints.tight(Size(w, h)));
+    colEl.paint(buffer, offset);
+    colEl.unmount();
   }
 }
 
@@ -88,19 +110,19 @@ class RadarWidget extends Widget {
   /// Current animation frame of the radar sweep.
   int frame = 0;
 
-  /// The rendering mode used by the canvas.
-  CanvasRenderMode renderMode;
-
-  /// Whether anti-aliasing is enabled.
-  bool antiAliased;
-
-  /// The base style applied to the canvas cells.
-  final Style style;
-
-  /// Cache canvas to avoid allocations on resize.
+  /// Internal sub-pixel Braille canvas cache.
   Canvas? canvas;
 
-  /// Creates a new [RadarWidget] with the given parameters.
+  /// Render mode.
+  CanvasRenderMode renderMode;
+
+  /// Anti-aliasing.
+  bool antiAliased;
+
+  /// Widget Style.
+  final Style style;
+
+  /// Construct the Radar simulation widget.
   RadarWidget({
     this.renderMode = CanvasRenderMode.braille,
     this.antiAliased = false,
@@ -108,118 +130,130 @@ class RadarWidget extends Widget {
   });
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final w = area.width;
-    final h = area.height;
-    if (w <= 0 || h <= 0) return;
+  Element createElement() => _RadarElement(this);
+}
 
-    if (canvas == null || canvas!.width != w || canvas!.height != h) {
-      canvas = Canvas(w, h, renderMode: renderMode, style: style);
+class _RadarElement extends Element {
+  _RadarElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = size.width;
+    final h = size.height;
+    if (w <= 0 || h <= 0) return;
+    final radar = widget as RadarWidget;
+
+    if (radar.canvas == null ||
+        radar.canvas!.width != w ||
+        radar.canvas!.height != h) {
+      radar.canvas = Canvas(
+        w,
+        h,
+        renderMode: radar.renderMode,
+        style: radar.style,
+      );
     } else {
-      canvas!.clear();
+      radar.canvas!.clear();
     }
 
-    canvas!.renderMode = renderMode;
+    radar.canvas!.renderMode = radar.renderMode;
 
     final cx = w;
     final cy = h * 2;
     final r = (min(w, h * 2) - 3).clamp(8, 25);
 
     // Draw static radar face cross-hairs and concentric circles
-    canvas!.drawCircle(
+    radar.canvas!.drawCircle(
       cx,
       cy,
       r,
       antiAliased: false,
       cellStyle: const Style(foreground: CharmColors.spinach),
     );
-    canvas!.drawCircle(
+    radar.canvas!.drawCircle(
       cx,
       cy,
-      (r * 0.67).round(),
+      (r * 0.66).round(),
       antiAliased: false,
       cellStyle: const Style(foreground: CharmColors.spinach),
     );
-    canvas!.drawCircle(
+    radar.canvas!.drawCircle(
       cx,
       cy,
       (r * 0.33).round(),
       antiAliased: false,
       cellStyle: const Style(foreground: CharmColors.spinach),
     );
-    canvas!.drawLine(
+
+    // Draw static axes
+    radar.canvas!.drawLine(
       cx - r,
       cy,
       cx + r,
       cy,
-      antiAliased: false,
       cellStyle: const Style(foreground: CharmColors.spinach),
     );
-    canvas!.drawLine(
+    radar.canvas!.drawLine(
       cx,
       cy - r,
       cx,
       cy + r,
-      antiAliased: false,
       cellStyle: const Style(foreground: CharmColors.spinach),
     );
 
-    final sweepAngle = (frame * 0.03) % (2 * pi);
-    final rx = cx + (r * cos(sweepAngle)).round();
-    final ry = cy + (r * sin(sweepAngle)).round();
-    canvas!.drawLineColored(
+    // Draw scanning sweep line
+    final sweepAngle = radar.frame * 0.05;
+    final sx = (cx + r * cos(sweepAngle)).round();
+    final sy = (cy + r * sin(sweepAngle)).round();
+    radar.canvas!.drawLine(
       cx,
       cy,
-      rx,
-      ry,
-      CharmColors.spinach,
-      CharmColors.julep,
-      antiAliased: antiAliased,
+      sx,
+      sy,
+      cellStyle: const Style(foreground: CharmColors.lichen),
     );
 
-    void drawBlip(int blipDist, double blipAngle) {
-      final bx = cx + (blipDist * cos(blipAngle)).round();
-      final by = cy + (blipDist * sin(blipAngle)).round();
+    // Draw sweeping radar cone gradient
+    final fadeSteps = 16;
+    for (var i = 1; i <= fadeSteps; i++) {
+      final angle = sweepAngle - (i * 0.04);
+      final ex = (cx + r * cos(angle)).round();
+      final ey = (cy + r * sin(angle)).round();
+      final greenFadeVal = (120 - (i * 7)).clamp(30, 255);
+      radar.canvas!.drawLine(
+        cx,
+        cy,
+        ex,
+        ey,
+        cellStyle: Style(foreground: Color(0, greenFadeVal, 0)),
+      );
+    }
 
-      var diff = sweepAngle - blipAngle;
-      while (diff < 0) {
-        diff += 2 * pi;
-      }
-      while (diff > 2 * pi) {
-        diff -= 2 * pi;
-      }
-
-      double intensity = 0.0;
-      if (diff < pi / 2) {
-        intensity = 1.0 - (diff / (pi / 2));
-      } else if (diff > 2 * pi - 0.05) {
-        intensity = 0.2;
-      }
-
-      if (intensity > 0.0) {
-        final cxCell = bx ~/ 2;
-        final cyCell = by ~/ 4;
-        if (cxCell >= 0 && cxCell < w && cyCell >= 0 && cyCell < h) {
-          int numDots = intensity > 0.75
-              ? 8
-              : (intensity > 0.5 ? 6 : (intensity > 0.25 ? 4 : 2));
-          final blipStyle = Style(
-            foreground: intensity > 0.6
-                ? CharmColors.mustard
-                : CharmColors.paprika,
-          );
-          for (var i = 0; i < numDots; i++) {
-            final dx = i % 2;
-            final dy = i ~/ 2;
-            canvas!.setPixel(
-              cxCell * 2 + dx,
-              cyCell * 4 + dy,
-              true,
-              antiAliased: antiAliased,
-              cellStyle: blipStyle,
-            );
-          }
-        }
+    // Dynamic blips
+    void drawBlip(int distance, double targetAngle) {
+      final difference = (sweepAngle - targetAngle) % (2 * pi);
+      if (difference < 1.5) {
+        final bx = (cx + distance * cos(targetAngle)).round();
+        final by = (cy + distance * sin(targetAngle)).round();
+        final brightness = ((1.5 - difference) / 1.5 * 255).round().clamp(
+          0,
+          255,
+        );
+        radar.canvas!.fillCircle(
+          bx,
+          by,
+          1,
+          antiAliased: false,
+          cellStyle: Style(
+            foreground: Color(brightness, brightness, 0),
+            modifiers: Modifier.bold,
+          ),
+        );
       }
     }
 
@@ -234,7 +268,10 @@ class RadarWidget extends Widget {
     drawBlip(blipDistance2.round(), blipAngle2);
     drawBlip(blipDistance3.round(), blipAngle3);
 
-    canvas!.render(buffer, Rect(0, 0, w, h));
+    final canvasEl = radar.canvas!.createElement()..mount(null);
+    canvasEl.layout(BoxConstraints.tight(Size(w, h)));
+    canvasEl.paint(buffer, offset);
+    canvasEl.unmount();
   }
 }
 
@@ -249,13 +286,13 @@ class SpinningCubeWidget extends Widget {
   /// Rotation angle around Z axis.
   double rotZ = 0.0;
 
-  /// The base style applied to the canvas cells.
-  final Style style;
-
-  /// Cache canvas to avoid allocations on resize.
+  /// Internal canvas cache.
   Canvas? canvas;
 
-  /// Creates a new [SpinningCubeWidget] with the given parameters.
+  /// Widget style.
+  final Style style;
+
+  /// Construct a spinning 3D cube widget.
   SpinningCubeWidget({this.style = Style.empty});
 
   /// Advance the rotation angles for the next frame simulation.
@@ -266,20 +303,35 @@ class SpinningCubeWidget extends Widget {
   }
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final w = area.width;
-    final h = area.height;
-    if (w <= 0 || h <= 0) return;
+  Element createElement() => _SpinningCubeElement(this);
+}
 
-    if (canvas == null || canvas!.width != w || canvas!.height != h) {
-      canvas = Canvas(
+class _SpinningCubeElement extends Element {
+  _SpinningCubeElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = size.width;
+    final h = size.height;
+    if (w <= 0 || h <= 0) return;
+    final cube = widget as SpinningCubeWidget;
+
+    if (cube.canvas == null ||
+        cube.canvas!.width != w ||
+        cube.canvas!.height != h) {
+      cube.canvas = Canvas(
         w,
         h,
         renderMode: CanvasRenderMode.quadrants,
-        style: style,
+        style: cube.style,
       );
     } else {
-      canvas!.clear();
+      cube.canvas!.clear();
     }
 
     // 8 vertices of a 3D cube
@@ -314,15 +366,15 @@ class SpinningCubeWidget extends Widget {
       final z = v[2];
 
       // Rotate X
-      final y1 = y * cos(rotX) - z * sin(rotX);
-      final z1 = y * sin(rotX) + z * cos(rotX);
+      final y1 = y * cos(cube.rotX) - z * sin(cube.rotX);
+      final z1 = y * sin(cube.rotX) + z * cos(cube.rotX);
 
       // Rotate Y
-      final x2 = x * cos(rotY) + z1 * sin(rotY);
+      final x2 = x * cos(cube.rotY) + z1 * sin(cube.rotY);
 
       // Rotate Z
-      final x3 = x2 * cos(rotZ) - y1 * sin(rotZ);
-      final y3 = x2 * sin(rotZ) + y1 * cos(rotZ);
+      final x3 = x2 * cos(cube.rotZ) - y1 * sin(cube.rotZ);
+      final y3 = x2 * sin(cube.rotZ) + y1 * cos(cube.rotZ);
 
       // Simple perspective/orthographic projection
       final px = (cx + x3 * scale * 1.6).round(); // aspect ratio adjustment
@@ -335,9 +387,12 @@ class SpinningCubeWidget extends Widget {
     for (final edge in edges) {
       final p1 = projected[edge[0]];
       final p2 = projected[edge[1]];
-      canvas!.drawLine(p1.x, p1.y, p2.x, p2.y, cellStyle: edgeStyle);
+      cube.canvas!.drawLine(p1.x, p1.y, p2.x, p2.y, cellStyle: edgeStyle);
     }
 
-    canvas!.render(buffer, Rect(0, 0, w, h));
+    final canvasEl = cube.canvas!.createElement()..mount(null);
+    canvasEl.layout(BoxConstraints.tight(Size(w, h)));
+    canvasEl.paint(buffer, offset);
+    canvasEl.unmount();
   }
 }

--- a/packages/termui_shared_examples/lib/window_manager_demo/window_manager_demo_widgets.dart
+++ b/packages/termui_shared_examples/lib/window_manager_demo/window_manager_demo_widgets.dart
@@ -15,23 +15,36 @@ class InfoWidget extends Widget {
   final List<String> keys = [];
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Element createElement() => _InfoElement(this);
+}
+
+class _InfoElement extends Element {
+  _InfoElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = widget as InfoWidget;
     buffer.writeString(
-      0,
-      0,
+      offset.dx,
+      offset.dy,
       'Click windows to focus.\nWin 1 onKeyEvent logs keys below.\nPress Q on other windows to quit.',
       const Style(foreground: Colors.white),
     );
     buffer.writeString(
-      0,
-      4,
-      'Focused Win: $focusedWindow',
+      offset.dx,
+      offset.dy + 4,
+      'Focused Win: ${w.focusedWindow}',
       const Style(foreground: Colors.orange, modifiers: Modifier.bold),
     );
     buffer.writeString(
-      0,
-      6,
-      'Win 1 Keys: ${keys.map((k) => k == '\r' || k == '\n' ? 'Enter' : k).join(" ")}',
+      offset.dx,
+      offset.dy + 6,
+      'Win 1 Keys: ${w.keys.map((k) => k == '\r' || k == '\n' ? 'Enter' : k).join(" ")}',
       const Style(foreground: Colors.green, modifiers: Modifier.bold),
     );
   }
@@ -55,29 +68,42 @@ class MouseTrackerWidget extends Widget {
   String lastTransition = 'None';
 
   @override
-  void render(Buffer buffer, Rect area) {
+  Element createElement() => _MouseTrackerElement(this);
+}
+
+class _MouseTrackerElement extends Element {
+  _MouseTrackerElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = widget as MouseTrackerWidget;
     buffer.writeString(
-      0,
-      0,
-      'Cursor Coords: ($mouseX, $mouseY)',
+      offset.dx,
+      offset.dy,
+      'Cursor Coords: (${w.mouseX}, ${w.mouseY})',
       const Style(foreground: Color(0, 255, 255), modifiers: Modifier.bold),
     );
     buffer.writeString(
-      0,
-      2,
-      'Hover Window: $hoverWindow',
+      offset.dx,
+      offset.dy + 2,
+      'Hover Window: ${w.hoverWindow}',
       const Style(foreground: Colors.white),
     );
     buffer.writeString(
-      0,
-      4,
-      'Event: $lastEvent',
+      offset.dx,
+      offset.dy + 4,
+      'Event: ${w.lastEvent}',
       const Style(foreground: Colors.white),
     );
     buffer.writeString(
-      0,
-      6,
-      'Log: $lastTransition',
+      offset.dx,
+      offset.dy + 6,
+      'Log: ${w.lastTransition}',
       const Style(foreground: Color(255, 255, 0)),
     );
   }
@@ -92,13 +118,26 @@ class SizeWidget extends Widget {
   SizeWidget(this.windowFn);
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final win = windowFn();
+  Element createElement() => _SizeElement(this);
+}
+
+class _SizeElement extends Element {
+  _SizeElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final wWidget = widget as SizeWidget;
+    final win = wWidget.windowFn();
     final w = win.bounds.width;
     final h = win.bounds.height;
     buffer.writeString(
-      0,
-      0,
+      offset.dx,
+      offset.dy,
       'Drag bottom corners (╚/╝) to resize.\n\nWidth:  $w\nHeight: $h',
       const Style(foreground: Colors.white),
     );
@@ -111,10 +150,24 @@ class BrailleCanvasWidget extends Widget {
   int frame = 0;
 
   @override
-  void render(Buffer buffer, Rect area) {
-    final w = area.width;
-    final h = area.height;
+  Element createElement() => _BrailleCanvasElement(this);
+}
+
+class _BrailleCanvasElement extends Element {
+  _BrailleCanvasElement(super.widget);
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(constraints.maxWidth, constraints.maxHeight);
+  }
+
+  @override
+  void paint(Buffer buffer, Offset offset) {
+    final w = size.width;
+    final h = size.height;
     if (w <= 0 || h <= 0) return;
+    final target = widget as BrailleCanvasWidget;
+    final frame = target.frame;
 
     final canvas = Canvas(w, h, style: const Style(foreground: Colors.green));
 
@@ -138,6 +191,9 @@ class BrailleCanvasWidget extends Widget {
       canvas.setPixel(px, py, true);
     }
 
-    canvas.render(buffer, Rect(0, 0, w, h));
+    final canvasEl = canvas.createElement()..mount(null);
+    canvasEl.layout(BoxConstraints.tight(Size(w, h)));
+    canvasEl.paint(buffer, offset);
+    canvasEl.unmount();
   }
 }


### PR DESCRIPTION
Decouple widget configurations from layout and paint operations by introducing a persistent element tree model similar to Flutter. This change eliminates the previous procedural rendering system and introduces robust lifecycle separation and reconciliation.

Key Changes:
- Remove direct `render(Buffer buffer, Rect area)` calls on [Widget](/packages/termui/lib/ui/layout.dart#L338) subclasses.
- Introduce [Element](/packages/termui/lib/ui/layout.dart#L356) subclasses (`StatelessElement`, `StatefulElement`, `LeafElement`, `InheritedElement`, and layout-specific elements like `RowElement`/`ColumnElement`) to manage mounting, unmounting, reconciliation, and layout/paint tasks.
- Re-route rendering flows through `performLayout(BoxConstraints constraints)` and `paint(Buffer buffer, Offset offset)` on [Element](/packages/termui/lib/ui/layout.dart#L356).
- Implement [LayoutBuilder](/packages/termui/lib/ui/widgets/layout_builder.dart#L9) to support building child subtrees dynamically based on parent-provided constraints.
- Refactor all built-in widgets (e.g. `Column`, `Row`, `Stack`, `DecoratedBox`, `Padding`, `TextField`, `ListWidget`, `Canvas`, etc.) to implement `createElement()`.
- Update package examples and entrypoints to wrap root layouts in `ElementWidget` and perform layout/paint passes correctly.
- Add milestone documentation (`03_responsive_dashboard.md`, `04_multi_pane.md`, `05_command_palette.md`) and unit/integration tests (`milestone2_lifecycle_test.dart`, `layout_builder_test.dart`, `geometry_test.dart`).

BREAKING CHANGE: Custom widgets must now implement `createElement()` and move their layout/drawing logic from `render` to custom `Element` subclasses implementing `performLayout` and `paint`.
