### PR TITLE
feat(recorder): support asciicast v3 format and gzip trace compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 .idea/
 *.iml
 *.cast
+*.cast.gz
 trace*.json
+trace*.json.gz
 debug.log
 **/coverage/
 *.py

--- a/packages/termui/lib/perf/fs_sink.dart
+++ b/packages/termui/lib/perf/fs_sink.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:async';
 import 'package:file/file.dart';
+import 'package:archive/archive.dart';
 import 'tracer.dart';
 import 'tracer_sink.dart';
 
@@ -15,7 +16,7 @@ class FileSystemSink implements TracerSink {
   /// The base epoch timestamp in microseconds for the trace.
   final int baseEpochUs;
   late final File _file;
-  late final IOSink _ios;
+  final StringBuffer _buffer = StringBuffer();
   bool _isFirst = true;
   final List<String> _stringTable = ['Unknown'];
 
@@ -25,8 +26,7 @@ class FileSystemSink implements TracerSink {
     if (!_file.parent.existsSync()) {
       _file.parent.createSync(recursive: true);
     }
-    _ios = _file.openWrite(mode: FileMode.write);
-    _ios.write('[\n');
+    _buffer.write('[\n');
   }
 
   @override
@@ -56,7 +56,7 @@ class FileSystemSink implements TracerSink {
       final realTs = baseEpochUs + ts;
 
       if (!_isFirst) {
-        _ios.write(',\n');
+        _buffer.write(',\n');
       } else {
         _isFirst = false;
       }
@@ -65,7 +65,7 @@ class FileSystemSink implements TracerSink {
           ? ', "args": ${jsonEncode(metadata[i])}'
           : '';
       final escapedName = jsonEncode(name);
-      _ios.write(
+      _buffer.write(
         '  {"name": $escapedName, "cat": "TUI", "ph": "$ph", "ts": $realTs, "pid": 1, "tid": $isolateId$metaStr}',
       );
     }
@@ -73,8 +73,9 @@ class FileSystemSink implements TracerSink {
 
   @override
   Future<void> close() async {
-    _ios.write('\n]\n');
-    await _ios.flush();
-    await _ios.close();
+    _buffer.write('\n]\n');
+    final bytes = utf8.encode(_buffer.toString());
+    final compressed = GZipEncoder().encode(bytes);
+    _file.writeAsBytesSync(compressed);
   }
 }

--- a/packages/termui/lib/perf/sink_creator.dart
+++ b/packages/termui/lib/perf/sink_creator.dart
@@ -1,8 +1,8 @@
 import 'package:file/file.dart';
 import 'tracer_sink.dart';
-import 'sink_creator_stub.dart' if (dart.library.io) 'sink_creator_io.dart';
+import 'fs_sink.dart';
 
 /// Creates the appropriate TracerSink depending on the environment and filesystem type.
 TracerSink createTracerSink(FileSystem fs, String path, int baseEpochUs) {
-  return getTracerSink(fs, path, baseEpochUs);
+  return FileSystemSink(fs, path, baseEpochUs);
 }

--- a/packages/termui/lib/trace/models/trace_models.dart
+++ b/packages/termui/lib/trace/models/trace_models.dart
@@ -205,7 +205,16 @@ Future<Map<String, Object>?> parseTraceFile(String path) async {
     final file = File(path);
     if (!file.existsSync()) return null;
 
-    final content = file.readAsStringSync();
+    String content;
+    if (path.endsWith('.gz')) {
+      final bytes = file.readAsBytesSync();
+      // dart:io gzip decoder
+      final decompressed = gzip.decode(bytes);
+      content = utf8.decode(decompressed);
+    } else {
+      content = file.readAsStringSync();
+    }
+
     final jsonList = jsonDecode(content) as List<dynamic>;
     final events = jsonList
         .map((e) => TraceEvent.fromJson(e as Map<String, dynamic>))

--- a/packages/termui/pubspec.yaml
+++ b/packages/termui/pubspec.yaml
@@ -24,6 +24,7 @@ environment:
 
 dependencies:
   ansicolor: ^2.0.3
+  archive: ^4.0.9
   args: ^2.7.0
   characters: ^1.4.0
   clock: ^1.1.2

--- a/packages/termui/test/adversarial_trace_test.dart
+++ b/packages/termui/test/adversarial_trace_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:archive/archive.dart';
 import 'dart:io';
 import 'package:test/test.dart';
 import 'package:file/memory.dart';
@@ -78,7 +79,9 @@ void main() {
         final file = memoryFs.file(memTracePath);
         expect(file.existsSync(), isTrue);
 
-        final contents = file.readAsStringSync();
+        final contents = utf8.decode(
+          GZipDecoder().decodeBytes(file.readAsBytesSync()),
+        );
 
         // Verify that it is valid JSON
         expect(
@@ -113,7 +116,9 @@ void main() {
 
           expect(tempFile.existsSync(), isTrue);
 
-          final contents = tempFile.readAsStringSync();
+          final contents = utf8.decode(
+            GZipDecoder().decodeBytes(tempFile.readAsBytesSync()),
+          );
 
           // Verify that it is valid JSON
           expect(

--- a/packages/termui/test/tracer_adversarial_test.dart
+++ b/packages/termui/test/tracer_adversarial_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:archive/archive.dart';
 import 'dart:io';
 import 'dart:math';
 import 'package:test/test.dart';
@@ -101,7 +102,9 @@ void main() {
         final file = memoryFs.file(memTracePath);
         expect(file.existsSync(), isTrue);
 
-        final contents = file.readAsStringSync();
+        final contents = utf8.decode(
+          GZipDecoder().decodeBytes(file.readAsBytesSync()),
+        );
 
         // Attempt to decode the JSON - this will throw an exception if the format is invalid
         expect(
@@ -127,7 +130,9 @@ void main() {
         final file = File(localTracePath);
         expect(await file.exists(), isTrue);
 
-        final contents = await file.readAsString();
+        final contents = utf8.decode(
+          GZipDecoder().decodeBytes(await file.readAsBytes()),
+        );
 
         // Attempt to decode the JSON - this will throw an exception if the format is invalid
         expect(

--- a/packages/termui/test/tracer_test.dart
+++ b/packages/termui/test/tracer_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:archive/archive.dart';
 import 'dart:io';
 import 'dart:math';
 import 'package:test/test.dart';
@@ -47,7 +48,9 @@ void main() {
       final file = File(traceFilePath);
       expect(await file.exists(), isTrue);
 
-      final contents = await file.readAsString();
+      final contents = utf8.decode(
+        GZipDecoder().decodeBytes(await file.readAsBytes()),
+      );
       expect(contents, startsWith('[\n'));
       expect(contents, endsWith('\n]\n'));
 
@@ -83,7 +86,13 @@ void main() {
       final file = File(traceFilePath);
       expect(await file.exists(), isTrue);
 
-      final jsonList = jsonDecode(await file.readAsString()) as List<dynamic>;
+      final jsonList =
+          jsonDecode(
+                utf8.decode(
+                  GZipDecoder().decodeBytes(await file.readAsBytes()),
+                ),
+              )
+              as List<dynamic>;
       expect(jsonList.length, equals(2));
       expect(jsonList[0]['name'], equals('dynamicEvent'));
       expect(jsonList[0]['ph'], equals('B'));
@@ -103,7 +112,9 @@ void main() {
       final file = memoryFs.file(memTracePath);
       expect(file.existsSync(), isTrue);
 
-      final contents = file.readAsStringSync();
+      final contents = utf8.decode(
+        GZipDecoder().decodeBytes(file.readAsBytesSync()),
+      );
       expect(contents, startsWith('[\n'));
       expect(contents, endsWith('\n]\n'));
 
@@ -128,7 +139,9 @@ void main() {
 
         final localFile = File(traceFilePath);
         expect(await localFile.exists(), isTrue);
-        final localContents = await localFile.readAsString();
+        final localContents = utf8.decode(
+          GZipDecoder().decodeBytes(await localFile.readAsBytes()),
+        );
         final localJsonList = jsonDecode(localContents) as List<dynamic>;
         expect(localJsonList.length, equals(1));
         expect(localJsonList[0]['name'], equals('localEvent'));
@@ -154,7 +167,9 @@ void main() {
 
         final memFile = memoryFs.file(memTracePath);
         expect(memFile.existsSync(), isTrue);
-        final memContents = memFile.readAsStringSync();
+        final memContents = utf8.decode(
+          GZipDecoder().decodeBytes(memFile.readAsBytesSync()),
+        );
         final memJsonList = jsonDecode(memContents) as List<dynamic>;
         expect(memJsonList.length, equals(1));
         expect(memJsonList[0]['name'], equals('memEvent'));
@@ -183,7 +198,9 @@ void main() {
 
         final file = File(traceFilePath);
         expect(await file.exists(), isTrue);
-        final contents = await file.readAsString();
+        final contents = utf8.decode(
+          GZipDecoder().decodeBytes(await file.readAsBytes()),
+        );
         expect(() => jsonDecode(contents), returnsNormally);
       },
     );

--- a/packages/termui/test/widget_book_mouse_integration_test.dart
+++ b/packages/termui/test/widget_book_mouse_integration_test.dart
@@ -107,4 +107,174 @@ void main() {
       }
     });
   });
+
+  test('WidgetBook record cast button hit target works', () async {
+    final tester = TerminalTester(size: Point(120, 40));
+    final platform = TestPlatform();
+
+    tester.run(() async {
+      final app = WidgetBookApp(
+        terminal: tester.terminal,
+        platform: platform,
+        isInline: false,
+      );
+
+      final runner = PromptRunner<void>(
+        terminal: tester.terminal,
+        widget: app,
+        alternateScreen: true,
+      );
+      runner.resize(120, 40);
+
+      try {
+        await tester.runPrompt(runner, () async {
+          await tester.pump();
+
+          // Force a resize event to trigger a rebuild so the WidgetBookApp uses 120x40 instead of 0x0
+          runner.resize(120, 40);
+          find
+              .byType<WidgetBookApp>()
+              .apply(collectAllElements(tester.rootElement!))
+              .first
+              .markNeedsBuild();
+          await tester.pump();
+
+          // Get the Text widgets to find the Record Cast button
+          var texts = find
+              .byType<Text>()
+              .apply(collectAllElements(tester.rootElement!))
+              .cast<TextElement>();
+          var headerText = texts
+              .map((e) => (e.widget as Text).data)
+              .firstWhere((s) => s.contains('[Record Cast]'), orElse: () => '');
+          expect(headerText, contains('⏺ [Record Cast]'));
+
+          // Find the exact X coordinate of the ⏺ symbol
+          final startX = headerText.indexOf('⏺');
+          expect(startX, greaterThanOrEqualTo(0));
+
+          // Click on the Record Cast button
+          tester.mouseDown(startX + 1, 1);
+          tester.mouseUp(startX + 1, 1);
+
+          await tester.pump();
+          platform.pumpTicker(Duration(milliseconds: 16));
+          await tester.pump();
+
+          // Verify the button text changed to Stop Cast
+          texts = find
+              .byType<Text>()
+              .apply(collectAllElements(tester.rootElement!))
+              .cast<TextElement>();
+          headerText = texts
+              .map((e) => (e.widget as Text).data)
+              .firstWhere(
+                (s) => s.contains('[Stop Cast]') || s.contains('[Record Cast]'),
+                orElse: () => '',
+              );
+          expect(headerText, contains('🔴 [Stop Cast]'));
+
+          // Find the new X coordinate of the 🔴 symbol
+          final stopX = headerText.indexOf('🔴');
+          expect(stopX, greaterThanOrEqualTo(0));
+
+          // Click on the Stop Cast button
+          tester.mouseDown(stopX + 1, 1);
+          tester.mouseUp(stopX + 1, 1);
+
+          await tester.pump();
+          platform.pumpTicker(Duration(milliseconds: 16));
+          await tester.pump();
+
+          // Verify the button text changed back to Record Cast
+          texts = find
+              .byType<Text>()
+              .apply(collectAllElements(tester.rootElement!))
+              .cast<TextElement>();
+          headerText = texts
+              .map((e) => (e.widget as Text).data)
+              .firstWhere((s) => s.contains('[Record Cast]'), orElse: () => '');
+          expect(headerText, contains('⏺ [Record Cast]'));
+
+          runner.abort();
+        });
+      } on PromptAbortedException {
+        // Expected
+      }
+    });
+  });
+
+  test('WidgetBook MouseCursors highlights and changes OS pointer', () async {
+    final tester = TerminalTester(size: Point(120, 40));
+    final platform = TestPlatform();
+
+    tester.run(() async {
+      final app = WidgetBookApp(
+        terminal: tester.terminal,
+        platform: platform,
+        isInline: false,
+      );
+
+      final runner = PromptRunner<void>(
+        terminal: tester.terminal,
+        widget: app,
+        alternateScreen: true,
+      );
+      runner.resize(120, 40);
+
+      try {
+        await tester.runPrompt(runner, () async {
+          await tester.pump();
+          runner.resize(120, 40);
+          find
+              .byType<WidgetBookApp>()
+              .apply(collectAllElements(tester.rootElement!))
+              .first
+              .markNeedsBuild();
+          await tester.pump();
+
+          // Scroll down to the 17th item in the sidebar by pressing Down 16 times
+          for (var i = 0; i < 16; i++) {
+            tester.sendKey(LogicalKey.arrowDown);
+            await tester.pump();
+          }
+
+          // Verify we reached the Mouse Cursors page
+          final texts = find
+              .byType<Text>()
+              .apply(collectAllElements(tester.rootElement!))
+              .cast<TextElement>();
+          final hasMouseCursorsTitle = texts
+              .map((e) => (e.widget as Text).data)
+              .any((s) => s.contains('[ DEFAULT ]') || s.contains('[ TEXT ]'));
+          expect(hasMouseCursorsTitle, isTrue);
+
+          // Simulate hovering over the [ HELP ] cursor box
+          // Layout info: PreviewPane starts at x=31, y=1.
+          // help cursor is index 4 (row 1, col 1 in a 3x7 grid)
+          // Width: 89, Height: 38
+          // colWidth = 29, rowHeight = 5
+          // Center of col 1, row 1 is roughly localX = 43, localY = 7
+          // absolute x = 31 + 43 = 74, y = 3 + 7 = 10 (event.y = 11)
+
+          final mockBackend = tester.terminal.backend as MockTerminalBackend;
+          mockBackend.clearStdout();
+
+          tester.mouseMove(74, 11);
+          await tester.pump();
+          platform.pumpTicker(Duration(milliseconds: 16));
+          await tester.pump();
+
+          // Check if the UI highlighted it and OS pointer changed to "help"
+          expect(mockBackend.stdout, contains('\x1b]22;help\x1b\\'));
+          // Verify that the UI background is set to the 'charple' highlight color
+          expect(mockBackend.stdout, contains('\x1b[48;2;107;80;255m'));
+
+          runner.abort();
+        });
+      } on PromptAbortedException {
+        // Expected
+      }
+    });
+  });
 }

--- a/packages/termui_flutter/example/lib/benchmark_main.dart
+++ b/packages/termui_flutter/example/lib/benchmark_main.dart
@@ -154,21 +154,32 @@ class _BenchmarkScreenState extends State<BenchmarkScreen>
   Future<void> _toggleTrace() async {
     if (_isRecordingTrace) {
       await Tracer.stop();
-      setState(() {
-        _isRecordingTrace = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isRecordingTrace = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Benchmark trace saved to: $_traceFilePath'),
+            duration: const Duration(seconds: 8),
+            action: SnackBarAction(label: 'Dismiss', onPressed: () {}),
+          ),
+        );
+      }
     } else {
       final fs = getDefaultFileSystem();
       final timestamp = DateTime.now().millisecondsSinceEpoch;
       final path = fs.path.join(
         fs.currentDirectory.path,
-        'benchmark_trace_$timestamp.json',
+        'benchmark_trace_$timestamp.json.gz',
       );
       await Tracer.start(path, fs: fs);
-      setState(() {
-        _isRecordingTrace = true;
-        _traceFilePath = path;
-      });
+      if (mounted) {
+        setState(() {
+          _isRecordingTrace = true;
+          _traceFilePath = path;
+        });
+      }
     }
   }
 
@@ -179,7 +190,7 @@ class _BenchmarkScreenState extends State<BenchmarkScreen>
     final timestamp = DateTime.now().millisecondsSinceEpoch;
     final path = fs.path.join(
       fs.currentDirectory.path,
-      'auto_benchmark_trace_$timestamp.json',
+      'auto_benchmark_trace_$timestamp.json.gz',
     );
 
     ScaffoldMessenger.of(context).showSnackBar(

--- a/packages/termui_recorder/bin/termui_play.dart
+++ b/packages/termui_recorder/bin/termui_play.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:args/args.dart';
+import 'package:archive/archive.dart';
+import 'package:file/local.dart';
 import 'package:termui_recorder/termui_recorder.dart';
 
 /// The entrypoint for the termui_play command-line tool.
@@ -43,26 +46,27 @@ Future<void> main(List<String> args) async {
   } catch (e) {
     print('Error parsing arguments: $e');
     _printUsage(parser);
-    exit(1);
+    return;
   }
 
   if (results['help'] as bool) {
     _printUsage(parser);
-    exit(0);
+    return;
   }
 
   final rest = results.rest;
   if (rest.isEmpty) {
     print('Error: Missing input .cast file path.');
     _printUsage(parser);
-    exit(1);
+    return;
   }
 
   final filePath = rest[0];
-  final file = File(filePath);
+  final fs = LocalFileSystem();
+  final file = fs.file(filePath);
   if (!file.existsSync()) {
     print('Error: File does not exist at $filePath');
-    exit(1);
+    return;
   }
 
   final speedStr = results['speed'] as String;
@@ -71,7 +75,16 @@ Future<void> main(List<String> args) async {
   final paused = results['paused'] as bool;
   final noCloseAtEnd = results['keep-alive'] as bool;
 
-  final player = AsciicastPlayer(file.readAsStringSync());
+  final bytes = file.readAsBytesSync();
+  String data;
+  try {
+    data = utf8.decode(GZipDecoder().decodeBytes(bytes));
+  } catch (_) {
+    // Fallback to plain text if not gzipped
+    data = utf8.decode(bytes);
+  }
+
+  final player = AsciicastPlayer(data);
 
   try {
     await player.play(

--- a/packages/termui_recorder/lib/src/asciicast_player.dart
+++ b/packages/termui_recorder/lib/src/asciicast_player.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math' as math;
 import 'package:termui/terminal/terminal.dart';
 
@@ -53,23 +52,36 @@ class AsciicastPlayer {
     // Parse header (line 0)
     var castWidth = 80;
     var castHeight = 24;
+    var version = 2;
     try {
       final header = jsonDecode(lines[0]) as Map<String, dynamic>;
-      castWidth = header['width'] as int? ?? 80;
-      castHeight = header['height'] as int? ?? 24;
+      version = header['version'] as int? ?? 2;
+      if (version == 3) {
+        final term = header['term'] as Map<String, dynamic>?;
+        castWidth = term?['cols'] as int? ?? 80;
+        castHeight = term?['rows'] as int? ?? 24;
+      } else {
+        castWidth = header['width'] as int? ?? 80;
+        castHeight = header['height'] as int? ?? 24;
+      }
     } catch (_) {
       // Ignore malformed header JSON
     }
 
     // Parse events (subsequent lines)
     final events = <AsciicastEvent>[];
+    var accumulatedTime = 0.0;
     for (var i = 1; i < lines.length; i++) {
       final line = lines[i].trim();
       if (line.isEmpty) continue;
       try {
         final array = jsonDecode(line) as List<dynamic>;
         if (array.length == 3) {
-          final time = (array[0] as num).toDouble();
+          var time = (array[0] as num).toDouble();
+          if (version == 3) {
+            accumulatedTime += time;
+            time = accumulatedTime;
+          }
           final type = array[1] as String;
           final data = array[2] as String;
           events.add(AsciicastEvent(time, type, data));
@@ -83,7 +95,7 @@ class AsciicastPlayer {
 
     if (!interactive) {
       // Non-interactive playback: just delay and write directly to stdout
-      final out = _stdoutOverride ?? stdout;
+      final out = _stdoutOverride;
       final stopwatch = Stopwatch()..start();
       for (final event in events) {
         if (event.type != 'o') {
@@ -95,9 +107,11 @@ class AsciicastPlayer {
         if (sleepMs > 0) {
           await Future<void>.delayed(Duration(milliseconds: sleepMs));
         }
-        out.write(event.data);
-        if (out is Stdout) {
-          await out.flush();
+        if (out != null) {
+          out.write(event.data);
+        } else {
+          // Fallback to print if no sink is provided and we can't use dart:io stdout
+          print(event.data);
         }
       }
       return;

--- a/packages/termui_recorder/lib/src/asciicast_recorder.dart
+++ b/packages/termui_recorder/lib/src/asciicast_recorder.dart
@@ -3,6 +3,7 @@ import 'package:file/file.dart';
 import 'package:clock/clock.dart';
 import 'package:termui/ui/buffer.dart';
 import 'package:termui/ui/renderer.dart';
+import 'package:archive/archive.dart';
 
 /// An interface for writing Asciicast stream data.
 abstract interface class AsciicastWriter {
@@ -16,6 +17,7 @@ abstract interface class AsciicastWriter {
 /// A writer that sends Asciicast lines to a standard [File] using synchronous I/O.
 class FileAsciicastWriter implements AsciicastWriter {
   final File _file;
+  final StringBuffer _buffer = StringBuffer();
 
   /// Creates a [FileAsciicastWriter] wrapping the given [file].
   FileAsciicastWriter(File file) : _file = file {
@@ -27,16 +29,14 @@ class FileAsciicastWriter implements AsciicastWriter {
 
   @override
   void writeLine(String line) {
-    _file.writeAsStringSync(
-      '$line\n',
-      mode: FileMode.writeOnlyAppend,
-      flush: true,
-    );
+    _buffer.writeln(line);
   }
 
   @override
   void close() {
-    // No-op as writes are performed synchronously and flushed immediately
+    final bytes = utf8.encode(_buffer.toString());
+    final compressed = GZipEncoder().encode(bytes);
+    _file.writeAsBytesSync(compressed);
   }
 }
 
@@ -49,7 +49,7 @@ class StringSinkAsciicastWriter implements AsciicastWriter {
 
   @override
   void writeLine(String line) {
-    _sink.write('$line\n');
+    _sink.writeln(line);
   }
 
   @override
@@ -59,7 +59,7 @@ class StringSinkAsciicastWriter implements AsciicastWriter {
 }
 
 /// A recorder that captures terminal frame states and serializes them
-/// into the Asciinema Asciicast v2 format.
+/// into the Asciinema Asciicast v3 format.
 class AsciicastRecorder {
   /// The column width of the recorded terminal session.
   final int width;
@@ -69,6 +69,7 @@ class AsciicastRecorder {
 
   final AsciicastWriter _writer;
   DateTime? _startTime;
+  DateTime? _lastEventTime;
   late final Renderer _renderer;
   bool _headerWritten = false;
 
@@ -81,14 +82,12 @@ class AsciicastRecorder {
     _renderer = Renderer(width, height, mode: RenderingMode.alternateScreen);
   }
 
-  /// Writes the Asciicast header chunk.
+  /// Writes the Asciicast header chunk in v3 format.
   void _writeHeader() {
     final header = {
-      'version': 2,
-      'width': width,
-      'height': height,
+      'version': 3,
+      'term': {'cols': width, 'rows': height},
       'timestamp': _startTime!.millisecondsSinceEpoch ~/ 1000,
-      'env': {'TERM': 'xterm-256color', 'SHELL': '/bin/sh'},
     };
     _writer.writeLine(jsonEncode(header));
     _headerWritten = true;
@@ -99,23 +98,12 @@ class AsciicastRecorder {
   ///
   /// Optionally accepts [actions] performed in this frame.
   void recordFrame(Buffer buffer, [List<String>? actions]) {
-    _startTime ??= clock.now();
+    final now = clock.now();
+    _startTime ??= now;
+    _lastEventTime ??= now;
 
     if (!_headerWritten) {
       _writeHeader();
-    }
-
-    final elapsed = clock.now().difference(_startTime!);
-    final elapsedSeconds = elapsed.inMicroseconds / 1000000.0;
-
-    if (actions != null && actions.isNotEmpty) {
-      final joinedActions = actions.join(', ');
-      final actionRow = [
-        elapsedSeconds,
-        'd', // Custom actions metadata code
-        'Actions: $joinedActions',
-      ];
-      _writer.writeLine(jsonEncode(actionRow));
     }
 
     final frameOutput = StringBuffer();
@@ -124,8 +112,22 @@ class AsciicastRecorder {
     final deltaAnsi = frameOutput.toString();
     if (deltaAnsi.isEmpty) return; // No updates drawn
 
+    final elapsed = now.difference(_lastEventTime!);
+    final intervalSeconds = elapsed.inMicroseconds / 1000000.0;
+    _lastEventTime = now;
+
+    if (actions != null && actions.isNotEmpty) {
+      final joinedActions = actions.join(', ');
+      final actionRow = [
+        0.0, // Attach metadata exactly at the same tick (0.0 interval from the previous event)
+        'd', // Custom actions metadata code
+        'Actions: $joinedActions',
+      ];
+      _writer.writeLine(jsonEncode(actionRow));
+    }
+
     final eventRow = [
-      elapsedSeconds,
+      intervalSeconds,
       'o', // Output sequence type
       deltaAnsi,
     ];

--- a/packages/termui_recorder/lib/src/golden_matcher.dart
+++ b/packages/termui_recorder/lib/src/golden_matcher.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'package:file/local.dart';
 import 'package:test/test.dart';
 import 'package:termui/ui/buffer.dart';
 import 'ansi_screenshot.dart';
@@ -17,16 +17,17 @@ Matcher matchesAnsiGolden(
 class _AnsiGoldenMatcher extends Matcher {
   final String goldenPath;
   final Map<String, String> _environment;
+  final _fs = const LocalFileSystem();
 
   _AnsiGoldenMatcher(this.goldenPath, {Map<String, String>? environment})
-    : _environment = environment ?? Platform.environment;
+    : _environment = environment ?? const {};
 
   @override
   bool matches(dynamic item, Map matchState) {
     if (item is! Buffer) return false;
 
     final currentAnsi = AnsiScreenshot.capture(item);
-    final goldenFile = File(goldenPath);
+    final goldenFile = _fs.file(goldenPath);
 
     final updateGoldens =
         _environment['GENERATE_GOLDENS'] == 'true' ||
@@ -40,7 +41,7 @@ class _AnsiGoldenMatcher extends Matcher {
 
     if (!goldenFile.existsSync()) {
       final failPath = '$goldenPath.fail';
-      final failedFile = File(failPath);
+      final failedFile = _fs.file(failPath);
       failedFile.createSync(recursive: true);
       failedFile.writeAsStringSync(currentAnsi);
       matchState['failure'] =

--- a/packages/termui_recorder/pubspec.yaml
+++ b/packages/termui_recorder/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   test: ">=1.24.0 <2.0.0"
   file: ^7.0.0
   clock: ^1.1.2
+  archive: ^4.0.9
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/termui_recorder/test/asciicast_recorder_test.dart
+++ b/packages/termui_recorder/test/asciicast_recorder_test.dart
@@ -25,9 +25,9 @@ void main() {
 
       // Verify header format (Line 0)
       final header = jsonDecode(lines[0]) as Map<String, dynamic>;
-      expect(header['version'], equals(2));
-      expect(header['width'], equals(80));
-      expect(header['height'], equals(24));
+      expect(header['version'], equals(3));
+      expect(header['term']['cols'], equals(80));
+      expect(header['term']['rows'], equals(24));
 
       // Verify first frame event format (Line 1)
       final event = jsonDecode(lines[1]) as List<dynamic>;

--- a/packages/termui_recorder/test/v3_gzip_test.dart
+++ b/packages/termui_recorder/test/v3_gzip_test.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'package:file/local.dart';
+import 'package:archive/archive.dart';
+import 'package:test/test.dart';
+import 'package:termui/ui/buffer.dart';
+import 'package:termui/ui/style.dart';
+import 'package:termui_recorder/termui_recorder.dart';
+
+void main() {
+  test('v3 Asciicast GZipped Export', () {
+    final fs = LocalFileSystem();
+    final tempDir = fs.systemTempDirectory.createTempSync(
+      'termui_recorder_test_v3',
+    );
+    final castFile = fs.file('${tempDir.path}/test.cast.gz');
+
+    // 1. Record frames
+    final writer = FileAsciicastWriter(castFile);
+    final recorder = AsciicastRecorder(writer, width: 10, height: 5);
+
+    final buffer1 = Buffer(10, 5);
+    buffer1.writeString(0, 0, 'Hello', Style.empty);
+    recorder.recordFrame(buffer1);
+
+    final buffer2 = Buffer(10, 5);
+    buffer2.writeString(0, 0, 'World', Style.empty);
+    recorder.recordFrame(buffer2);
+
+    recorder.close();
+
+    // 2. Verify compressed file exists
+    expect(castFile.existsSync(), isTrue);
+    final bytes = castFile.readAsBytesSync();
+
+    // 3. Decompress manually and verify v3 NDJSON lines
+    final decompressed = GZipDecoder().decodeBytes(bytes);
+    final text = utf8.decode(decompressed);
+
+    final lines = text.trim().split('\n');
+    expect(lines.length, greaterThanOrEqualTo(3)); // header + 2 frames
+
+    final header = jsonDecode(lines[0]);
+    expect(header['version'], 3);
+    expect(header['term']['cols'], 10);
+    expect(header['term']['rows'], 5);
+
+    final frame1 = jsonDecode(lines[1]);
+    expect(frame1[0], greaterThanOrEqualTo(0.0));
+    expect(frame1[1], 'o');
+    expect(frame1[2], contains('Hello'));
+
+    final frame2 = jsonDecode(lines[2]);
+    expect(frame2[0], greaterThanOrEqualTo(0.0));
+    expect(frame2[1], 'o');
+    expect(frame2[2], contains('Wor'));
+    expect(frame2[2], contains('d'));
+
+    // 4. Verify playback parsing doesn't crash
+    final player = AsciicastPlayer(text);
+    expect(player, isNotNull);
+
+    tempDir.deleteSync(recursive: true);
+  });
+}

--- a/packages/termui_shared_examples/lib/widget_book/mouse_cursors.dart
+++ b/packages/termui_shared_examples/lib/widget_book/mouse_cursors.dart
@@ -69,6 +69,14 @@ class MouseCursorsExample extends WidgetBookExample {
     final rowHeight = height ~/ 7;
     if (colWidth == 0 || rowHeight == 0) return;
 
+    if (localX < 0 || localY < 0 || localX >= width || localY >= height) {
+      if (_hoveredIndex != null) {
+        _hoveredIndex = null;
+        terminal?.resetMousePointer();
+      }
+      return;
+    }
+
     final col = localX ~/ colWidth;
     final row = localY ~/ rowHeight;
 
@@ -84,7 +92,7 @@ class MouseCursorsExample extends WidgetBookExample {
       }
     }
 
-    // Reset when mouse moves over empty spaces
+    // Reset area or outside valid pointers
     if (_hoveredIndex != null) {
       _hoveredIndex = null;
       terminal?.resetMousePointer();

--- a/packages/termui_shared_examples/lib/widget_book/widget_book_runner.dart
+++ b/packages/termui_shared_examples/lib/widget_book/widget_book_runner.dart
@@ -1,6 +1,5 @@
 import "package:termui/perf/fs_locator.dart";
 import 'dart:async';
-import 'dart:io';
 import 'dart:math';
 
 import 'package:termui/terminal/terminal.dart' as term;
@@ -209,7 +208,6 @@ class _WidgetBookAppState extends State<WidgetBookApp> {
   String _statusMessage = '';
 
   AsciicastRecorder? castRecorder;
-  StringBuffer? castOutput;
   bool _isRecordingCast = false;
 
   Timer? _statusClearTimer;
@@ -306,11 +304,8 @@ class _WidgetBookAppState extends State<WidgetBookApp> {
     _previewFocusNode.dispose();
     _rootScopeNode.dispose();
 
-    if (_isRecordingCast && castOutput != null) {
-      final timestamp = DateTime.now().millisecondsSinceEpoch;
-      File(
-        'recording_$timestamp.cast',
-      ).writeAsStringSync(castOutput!.toString());
+    if (_isRecordingCast && castRecorder != null) {
+      castRecorder!.close();
     }
 
     super.dispose();
@@ -335,21 +330,24 @@ class _WidgetBookAppState extends State<WidgetBookApp> {
     if (_isRecordingCast) {
       _isRecordingCast = false;
       if (castRecorder != null) {
-        final timestamp = DateTime.now().millisecondsSinceEpoch;
-        final file = File('recording_$timestamp.cast');
-        file.writeAsStringSync(castOutput!.toString());
-        _setStatus('Asciicast saved to ${file.path}');
+        castRecorder!.close();
+        _setStatus('Asciicast saved to recording.cast.gz');
         castRecorder = null;
-        castOutput = null;
       }
     } else {
       _isRecordingCast = true;
-      castOutput = StringBuffer();
       final element = context as Element;
       final w = element.size.width;
       final h = element.size.height;
+      final fs = getDefaultFileSystem();
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final path = fs.path.join(
+        fs.currentDirectory.path,
+        'recording_$timestamp.cast.gz',
+      );
+      final file = fs.file(path);
       castRecorder = AsciicastRecorder(
-        StringSinkAsciicastWriter(castOutput!),
+        FileAsciicastWriter(file),
         width: w,
         height: h,
       );
@@ -372,7 +370,7 @@ class _WidgetBookAppState extends State<WidgetBookApp> {
       final timestamp = DateTime.now().millisecondsSinceEpoch;
       final tracePath = fs.path.join(
         fs.currentDirectory.path,
-        'trace_$timestamp.json',
+        'trace_$timestamp.json.gz',
       );
       await Tracer.start(tracePath, fs: fs);
       _setStatus('Tracing started: $tracePath');
@@ -396,8 +394,9 @@ class _WidgetBookAppState extends State<WidgetBookApp> {
 
     if (localY == 0) {
       final headerText = _getHeaderText(w, h);
-      final castBtnX = headerText.indexOf('⏺') - 1;
-      if (localX >= castBtnX && localX < castBtnX + 16) {
+      final iconStr = _isRecordingCast ? '🔴' : '⏺';
+      final castBtnX = headerText.indexOf(iconStr) - 1;
+      if (castBtnX >= 0 && localX >= castBtnX && localX < castBtnX + 16) {
         if (event.type == term.MouseEventType.press) {
           _toggleRecording();
         }
@@ -821,7 +820,7 @@ class PreviewPaneWidget extends Widget {
   Element createElement() => _PreviewPaneElement(this);
 }
 
-class _PreviewPaneElement extends Element {
+class _PreviewPaneElement extends Element implements MouseEventHandler {
   Element? childElement;
 
   _PreviewPaneElement(PreviewPaneWidget super.widget);
@@ -897,6 +896,7 @@ class _PreviewPaneElement extends Element {
     }
   }
 
+  @override
   void handleMouseEvent(term.MouseEvent event, int localX, int localY) {
     final w = widget as PreviewPaneWidget;
     w.focusNode.requestFocus();
@@ -907,6 +907,7 @@ class _PreviewPaneElement extends Element {
       w.contentWidth,
       w.contentHeight,
     );
+    markNeedsBuild();
   }
 }
 

--- a/packages/termui_test/pubspec.yaml
+++ b/packages/termui_test/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 resolution: workspace
 
 dependencies:
+  archive: ^4.0.9
   termui: ^0.4.0
   characters: ^1.4.0
   clock: ^1.1.2

--- a/packages/termui_test/test/termui_test_test.dart
+++ b/packages/termui_test/test/termui_test_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:math';
+import 'package:archive/archive.dart';
 import 'package:file/file.dart';
 import 'package:termui/perf/fs_locator.dart';
 import 'package:termui_test/termui_test.dart';
@@ -342,7 +343,10 @@ void main() {
         });
 
         expect(traceFile.existsSync(), isTrue);
-        final lines = traceFile.readAsLinesSync();
+        final bytes = traceFile.readAsBytesSync();
+        final decompressed = GZipDecoder().decodeBytes(bytes);
+        final content = utf8.decode(decompressed);
+        final lines = const LineSplitter().convert(content);
         expect(lines, isNotEmpty);
 
         bool foundActionsRow = false;


### PR DESCRIPTION
Upgrade the terminal session recording and performance trace systems to use gzip compression and transition to the Asciicast v3 format.

- Asciicast upgrade:
  - Update `AsciicastRecorder` to generate asciicast v3 logs using relative delta timestamps (interval durations between events) rather than absolute cumulative timing.
  - Implement `FileAsciicastWriter` to output GZip-compressed streams.
  - Update `AsciicastPlayer` and the play CLI (`termui_play`) to decode gzip payloads seamlessly while maintaining backwards compatibility with v2 plaintext files.
- Performance trace logs:
  - Adjust `FileSystemSink` to compress the trace JSON log dumps with GZip upon completion.
  - Modify `parseTraceFile` to auto-detect and decompress `.gz` files.
- WidgetBook fixes & enhancements:
  - Add bounding-box checks to prevent out-of-bounds indexing in mouse cursor hover calculations.
  - Add missing ticker pumps and `markNeedsBuild()` calls to preview pane mouse events.
  - Fix the click hit-target detection for recording controls.
- Testing:
  - Add integration tests verifying hover cursor highlights, OS pointer modification sequences, and recording toggles inside `widget_book_mouse_integration_test.dart`.