### PR TITLE
fix(testing): resolve pumpAndSettle timeouts and fakeAsync

### DIFF
--- a/packages/termui/lib/ui/widgets/core/prompt_runner.dart
+++ b/packages/termui/lib/ui/widgets/core/prompt_runner.dart
@@ -182,6 +182,9 @@ class PromptRunner<T> implements ListenableSceneRenderer {
   @override
   bool get isDirty => _buildOwner?.isDirtyElements.isNotEmpty ?? false;
 
+  /// Exposes whether a draw frame is currently scheduled.
+  bool get hasScheduledFrame => _drawScheduled;
+
   Point<int>? _lastMousePosition;
   Element? _mouseCaptureElement;
   BuildOwner? _buildOwner;

--- a/packages/termui/test/termui_trace_save_modal_test.dart
+++ b/packages/termui/test/termui_trace_save_modal_test.dart
@@ -29,75 +29,78 @@ void main() {
     final minTs = 1000;
     final maxTs = 2500;
 
-    test('Integration test: Save modal saves, dismisses and shows 3s message', () {
-      final fs = MemoryFileSystem();
-      final tester = TerminalTester(size: const Point(80, 24));
-      tester.run(() async {
-        globalSceneManager = SceneManager(
-          tester.terminal,
-          renderingMode: RenderingMode.alternateScreen,
-        );
-        globalSceneManager.enableMouseTracking = true;
+    test(
+      'Integration test: Save modal saves, dismisses and shows 3s message',
+      () {
+        final fs = MemoryFileSystem();
+        final tester = TerminalTester(size: const Point(80, 24));
+        tester.run(() async {
+          globalSceneManager = SceneManager(
+            tester.terminal,
+            renderingMode: RenderingMode.alternateScreen,
+          );
+          globalSceneManager.enableMouseTracking = true;
 
-        final app = TraceViewerApp(
-          spans: spans,
-          minTs: minTs,
-          maxTs: maxTs,
-          fileSystem: fs,
-        );
+          final app = TraceViewerApp(
+            spans: spans,
+            minTs: minTs,
+            maxTs: maxTs,
+            fileSystem: fs,
+          );
 
-        final runner = PromptRunner<void>(
-          terminal: tester.terminal,
-          widget: app,
-          alternateScreen: false,
-          mode: ExecutionMode.managed,
-          onFramePainted: (_) => globalSceneManager.render(),
-        );
+          final runner = PromptRunner<void>(
+            terminal: tester.terminal,
+            widget: app,
+            alternateScreen: false,
+            mode: ExecutionMode.managed,
+            onFramePainted: (_) => globalSceneManager.render(),
+          );
 
-        final appLayer = SceneLayer(
-          renderer: runner,
-          sizing: LayerSizing.fullscreen,
-        );
-        globalSceneManager.layers.add(appLayer);
-        globalSceneManager.focusedLayer = appLayer;
+          final appLayer = SceneLayer(
+            renderer: runner,
+            sizing: LayerSizing.fullscreen,
+          );
+          globalSceneManager.layers.add(appLayer);
+          globalSceneManager.focusedLayer = appLayer;
 
-        await tester.runPrompt(runner, () async {
-          await tester.pump();
-          final state = findTraceViewerState(tester.rootElement!);
+          await tester.runPrompt(runner, () async {
+            await tester.pump();
+            final state = findTraceViewerState(tester.rootElement!);
 
-          // Press Ctrl+S to spawn modal (we have no selection, so it selects all)
-          tester.sendKey(LogicalKey.character('s'), control: true);
-          await tester.pump();
+            // Press Ctrl+S to spawn modal (we have no selection, so it selects all)
+            tester.sendKey(LogicalKey.character('s'), control: true);
+            await tester.pump();
 
-          expect(globalSceneManager.layers.length, equals(2));
+            expect(globalSceneManager.layers.length, equals(2));
 
-          // Press Enter to submit
-          tester.sendKey(LogicalKey.enter);
-          await tester.pump();
+            // Press Enter to submit
+            tester.sendKey(LogicalKey.enter);
+            await tester.pump();
 
-          // Modal should be dismissed
-          expect(globalSceneManager.layers.length, equals(1));
+            // Modal should be dismissed
+            expect(globalSceneManager.layers.length, equals(1));
 
-          // File should exist
-          final exportedFile = fs.file('trace_cropped.json');
-          expect(exportedFile.existsSync(), isTrue);
+            // File should exist
+            final exportedFile = fs.file('trace_cropped.json');
+            expect(exportedFile.existsSync(), isTrue);
 
-          // exportMessage should be set
-          expect(state.exportMessage, isNotNull);
-          expect(state.exportMessage, contains('Exported'));
+            // exportMessage should be set
+            expect(state.exportMessage, isNotNull);
+            expect(state.exportMessage, contains('Exported'));
 
-          // Wait 3 seconds using Future.delayed so fakeAsync elapses it safely
-          await Future.delayed(const Duration(seconds: 3));
+            // Wait 3 seconds using pump so fakeAsync elapses it safely
+            await tester.pump(const Duration(seconds: 3));
 
-          // Message should be gone
-          expect(state.exportMessage, isNull);
+            // Message should be gone
+            expect(state.exportMessage, isNull);
 
-          runner.dispose();
+            runner.dispose();
+          });
+
+          globalSceneManager.dispose();
         });
-
-        globalSceneManager.dispose();
-      });
-    });
+      },
+    );
 
     test('Integration test: Save modal [x] dismisses without saving', () {
       final fs = MemoryFileSystem();

--- a/packages/termui_test/lib/src/tester.dart
+++ b/packages/termui_test/lib/src/tester.dart
@@ -232,7 +232,20 @@ class TerminalTester {
 
         try {
           while (!completed) {
-            async.elapse(const Duration(milliseconds: 1));
+            if (async.microtaskCount == 0 && !completed) {
+              if (async.pendingTimers.isNotEmpty) {
+                throw StateError(
+                  'TerminalTester test is stuck: a timer is pending but time is not advancing. '
+                  'Make sure to call tester.pump(duration) to advance time.',
+                );
+              } else {
+                throw StateError(
+                  'TerminalTester test is stuck: the event loop is idle but the test has not completed. '
+                  'Are you awaiting a Future that never completes?',
+                );
+              }
+            }
+            async.flushMicrotasks();
           }
         } finally {
           PromptRunner.onPromptStarted = oldOnPromptStarted;
@@ -314,12 +327,22 @@ class TerminalTester {
     await pump();
     count++;
 
-    while (_fakeAsync != null &&
-        (_fakeAsync!.pendingTimers.isNotEmpty ||
-            _fakeAsync!.microtaskCount > 0)) {
+    while (_fakeAsync != null) {
       if (watch.elapsed > timeout) {
         throw TimeoutException('pumpAndSettle timed out');
       }
+
+      final hasPendingWork = _runner != null
+          ? (_runner!.isDirty ||
+                _runner!.hasScheduledFrame ||
+                _fakeAsync!.pendingTimers.isNotEmpty)
+          : (_fakeAsync!.pendingTimers.isNotEmpty ||
+                _fakeAsync!.microtaskCount > 0);
+
+      if (!hasPendingWork) {
+        break;
+      }
+
       await pump(duration);
       count++;
     }

--- a/packages/termui_test/test/termui_test_test.dart
+++ b/packages/termui_test/test/termui_test_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 import 'package:archive/archive.dart';
@@ -372,5 +373,38 @@ void main() {
         }
       },
     );
+
+    test('pumpAndSettle does not time out with background microtasks', () {
+      final tester = TerminalTester();
+      tester.run(() async {
+        final runner = PromptRunner<void>(
+          terminal: tester.terminal,
+          widget: const Text('Test Screen'),
+        );
+
+        final runnerFuture = tester.runPrompt(runner, () async {
+          await tester.pump();
+
+          final future = tester.pumpAndSettle(
+            timeout: const Duration(seconds: 1),
+          );
+
+          void scheduleChain(int depth) {
+            if (depth > 0) {
+              scheduleMicrotask(() => scheduleChain(depth - 1));
+            }
+          }
+
+          scheduleMicrotask(() => scheduleChain(5));
+
+          final pumpCount = await future;
+          expect(pumpCount, equals(1));
+
+          runner.dispose();
+        });
+
+        await runnerFuture;
+      });
+    });
   });
 }


### PR DESCRIPTION
- Expose `hasScheduledFrame` on `PromptRunner` to track queued frame renders.
- Optimize `pumpAndSettle` to check `isDirty`, `hasScheduledFrame`, and `pendingTimers` when a prompt runner is active, completely avoiding timeouts on background microtasks.
- Refactor the `TerminalTester.run` outer driver loop to only flush microtasks and raise a descriptive `StateError` if the test gets stuck (idle event loop with incomplete future or pending timers). This removes the background `elapse` loop entirely.
- Revert `TerminalTester.pump` back to calling `_fakeAsync?.elapse` directly, returning clock control to the user's explicit pump calls.
- Update `termui_trace_save_modal_test.dart` to use `tester.pump` instead of `Future.delayed` for time advancement.
- Add a unit test verifying `pumpAndSettle` settles on the first pump with active background microtasks.

fixes: #48 