### PR TITLE
fix(termui): support wide characters and CJK in LazyTable without layout shifting

### DIFF
--- a/packages/termui/lib/ui/widgets/display/lazy_table.dart
+++ b/packages/termui/lib/ui/widgets/display/lazy_table.dart
@@ -263,6 +263,42 @@ class LazyTableElement extends Element {
     return constraints.constrain(Size(width, height));
   }
 
+  String _padOrTruncate(String text, int width) {
+    // 1. ASCII Fast-Path: bypass characters allocation for standard text
+    var isAscii = true;
+    final len = text.length;
+    for (var i = 0; i < len; i++) {
+      if (text.codeUnitAt(i) >= 128) {
+        isAscii = false;
+        break;
+      }
+    }
+
+    if (isAscii) {
+      if (len == width) return text;
+      if (len > width) return text.substring(0, width);
+      return text.padRight(width);
+    }
+
+    // 2. Slow-Path fallback for CJK and Emoji text
+    final cellWidth = measureStringWidth(text);
+    if (cellWidth == width) return text;
+    if (cellWidth < width) return text + (' ' * (width - cellWidth));
+
+    var currentWidth = 0;
+    final sb = StringBuffer();
+    for (final char in text.characters) {
+      final charWidth = isWideGrapheme(char) ? 2 : 1;
+      if (currentWidth + charWidth > width) break;
+      sb.write(char);
+      currentWidth += charWidth;
+    }
+    if (currentWidth < width) {
+      sb.write(' ' * (width - currentWidth));
+    }
+    return sb.toString();
+  }
+
   @override
   void performPaint(Buffer buffer, Offset offset) {
     final table = widget as LazyTable;
@@ -276,23 +312,31 @@ class LazyTableElement extends Element {
 
     if (usableHeight <= 0) return;
 
+    // Cache total column layout width (columns + single space separators)
+    final int columnsTotalWidth =
+        resolvedColumnWidths.fold<int>(0, (prev, val) => prev + val) +
+        (table.headers.isNotEmpty ? table.headers.length - 1 : 0);
+
     // 1. Render Headers
     if (hasHeaders) {
       final headerSb = StringBuffer();
       for (var i = 0; i < table.headers.length; i++) {
         final width = resolvedColumnWidths[i];
         final text = table.headers[i];
-        final chars = text.characters;
-        final padded = chars.length >= width
-            ? chars.take(width).toString()
-            : chars.toString() + (' ' * (width - chars.length));
+        final padded = _padOrTruncate(text, width);
         headerSb.write(padded);
         if (i < table.headers.length - 1) headerSb.write(' ');
       }
-      final headerChars = headerSb.toString().characters;
-      final headerStr = headerChars.length >= w
-          ? headerChars.take(w).toString()
-          : headerChars.toString() + (' ' * (w - headerChars.length));
+
+      String headerStr;
+      if (columnsTotalWidth <= w) {
+        if (columnsTotalWidth < w) {
+          headerSb.write(' ' * (w - columnsTotalWidth));
+        }
+        headerStr = headerSb.toString();
+      } else {
+        headerStr = _padOrTruncate(headerSb.toString(), w);
+      }
       buffer.writeString(offset.dx, offset.dy, headerStr, table.headerStyle);
 
       // Render Divider Line
@@ -314,28 +358,23 @@ class LazyTableElement extends Element {
       for (var c = 0; c < table.headers.length; c++) {
         final width = resolvedColumnWidths[c];
         final cellText = c < rowData.length ? rowData[c] : '';
-        final chars = cellText.characters;
-        final padded = chars.length >= width
-            ? chars.take(width).toString()
-            : chars.toString() + (' ' * (width - chars.length));
+        final padded = _padOrTruncate(cellText, width);
         rowSb.write(padded);
         if (c < table.headers.length - 1) rowSb.write(' ');
       }
 
-      final rowChars = rowSb.toString().characters;
+      String rowStr;
+      if (columnsTotalWidth <= w) {
+        if (columnsTotalWidth < w) {
+          rowSb.write(' ' * (w - columnsTotalWidth));
+        }
+        rowStr = rowSb.toString();
+      } else {
+        rowStr = _padOrTruncate(rowSb.toString(), w);
+      }
       final targetY = offset.dy + headerRowsCount + r;
 
-      for (var x = 0; x < w; x++) {
-        final char = x < rowChars.length ? rowChars.elementAt(x) : ' ';
-        buffer.setAttributes(
-          (offset.dx + x).toInt(),
-          targetY.toInt(),
-          char: char,
-          fg: currentStyle.foreground?.argb,
-          bg: currentStyle.background?.argb,
-          modifiers: currentStyle.modifiers,
-        );
-      }
+      buffer.writeString(offset.dx, targetY, rowStr, currentStyle);
     }
   }
 }

--- a/packages/termui/lib/ui/widgets/display/lazy_table.dart
+++ b/packages/termui/lib/ui/widgets/display/lazy_table.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'package:characters/characters.dart';
 import 'package:termui/termui.dart';
 
 /// A virtual scrolling list widget. Only renders items within the visible viewport.
@@ -263,42 +262,6 @@ class LazyTableElement extends Element {
     return constraints.constrain(Size(width, height));
   }
 
-  String _padOrTruncate(String text, int width) {
-    // 1. ASCII Fast-Path: bypass characters allocation for standard text
-    var isAscii = true;
-    final len = text.length;
-    for (var i = 0; i < len; i++) {
-      if (text.codeUnitAt(i) >= 128) {
-        isAscii = false;
-        break;
-      }
-    }
-
-    if (isAscii) {
-      if (len == width) return text;
-      if (len > width) return text.substring(0, width);
-      return text.padRight(width);
-    }
-
-    // 2. Slow-Path fallback for CJK and Emoji text
-    final cellWidth = measureStringWidth(text);
-    if (cellWidth == width) return text;
-    if (cellWidth < width) return text + (' ' * (width - cellWidth));
-
-    var currentWidth = 0;
-    final sb = StringBuffer();
-    for (final char in text.characters) {
-      final charWidth = isWideGrapheme(char) ? 2 : 1;
-      if (currentWidth + charWidth > width) break;
-      sb.write(char);
-      currentWidth += charWidth;
-    }
-    if (currentWidth < width) {
-      sb.write(' ' * (width - currentWidth));
-    }
-    return sb.toString();
-  }
-
   @override
   void performPaint(Buffer buffer, Offset offset) {
     final table = widget as LazyTable;
@@ -323,7 +286,7 @@ class LazyTableElement extends Element {
       for (var i = 0; i < table.headers.length; i++) {
         final width = resolvedColumnWidths[i];
         final text = table.headers[i];
-        final padded = _padOrTruncate(text, width);
+        final padded = padOrTruncate(text, width);
         headerSb.write(padded);
         if (i < table.headers.length - 1) headerSb.write(' ');
       }
@@ -335,7 +298,7 @@ class LazyTableElement extends Element {
         }
         headerStr = headerSb.toString();
       } else {
-        headerStr = _padOrTruncate(headerSb.toString(), w);
+        headerStr = padOrTruncate(headerSb.toString(), w);
       }
       buffer.writeString(offset.dx, offset.dy, headerStr, table.headerStyle);
 
@@ -358,7 +321,7 @@ class LazyTableElement extends Element {
       for (var c = 0; c < table.headers.length; c++) {
         final width = resolvedColumnWidths[c];
         final cellText = c < rowData.length ? rowData[c] : '';
-        final padded = _padOrTruncate(cellText, width);
+        final padded = padOrTruncate(cellText, width);
         rowSb.write(padded);
         if (c < table.headers.length - 1) rowSb.write(' ');
       }
@@ -370,7 +333,7 @@ class LazyTableElement extends Element {
         }
         rowStr = rowSb.toString();
       } else {
-        rowStr = _padOrTruncate(rowSb.toString(), w);
+        rowStr = padOrTruncate(rowSb.toString(), w);
       }
       final targetY = offset.dy + headerRowsCount + r;
 

--- a/packages/termui/lib/ui/widgets/display/table.dart
+++ b/packages/termui/lib/ui/widgets/display/table.dart
@@ -1,4 +1,3 @@
-import 'package:characters/characters.dart';
 import 'package:termui/termui.dart';
 
 /// A widget for displaying tabular columns of data with optional row selection.
@@ -250,17 +249,24 @@ class TableElement extends Element {
     for (var i = 0; i < table.headers.length; i++) {
       final width = resolvedColumnWidths[i];
       final text = table.headers[i];
-      final chars = text.characters;
-      final padded = chars.length >= width
-          ? chars.take(width).toString()
-          : chars.toString() + (' ' * (width - chars.length));
+      final padded = padOrTruncate(text, width);
       headerSb.write(padded);
       if (i < table.headers.length - 1) headerSb.write(' ');
     }
-    final headerChars = headerSb.toString().characters;
-    final headerStr = headerChars.length >= w
-        ? headerChars.take(w).toString()
-        : headerChars.toString() + (' ' * (w - headerChars.length));
+
+    final int columnsTotalWidth =
+        resolvedColumnWidths.fold<int>(0, (prev, val) => prev + val) +
+        (table.headers.isNotEmpty ? table.headers.length - 1 : 0);
+
+    String headerStr;
+    if (columnsTotalWidth <= w) {
+      if (columnsTotalWidth < w) {
+        headerSb.write(' ' * (w - columnsTotalWidth));
+      }
+      headerStr = headerSb.toString();
+    } else {
+      headerStr = padOrTruncate(headerSb.toString(), w);
+    }
     buffer.writeString(offset.dx, offset.dy, headerStr, table.headerStyle);
 
     // 2. Render Header Divider Line
@@ -305,10 +311,7 @@ class TableElement extends Element {
           }
         } else {
           final cellText = cellData.toString();
-          final chars = cellText.characters;
-          final padded = chars.length >= colWidth
-              ? chars.take(colWidth).toString()
-              : chars.toString() + (' ' * (colWidth - chars.length));
+          final padded = padOrTruncate(cellText, colWidth);
           vp.writeString(0, 0, padded, currentStyle);
         }
 

--- a/packages/termui/lib/ui/widgets/display/text.dart
+++ b/packages/termui/lib/ui/widgets/display/text.dart
@@ -28,6 +28,47 @@ int measureStringWidth(String text) {
   return width;
 }
 
+/// Pads or truncates a string to match the specified visual column width in a terminal,
+/// correctly accounting for wide characters (CJK and Emoji) and utilizing a fast-path
+/// for pure ASCII text.
+String padOrTruncate(String text, int width) {
+  if (width <= 0) return '';
+
+  // 1. ASCII Fast-Path: bypass characters allocation for standard text
+  var isAscii = true;
+  final len = text.length;
+  for (var i = 0; i < len; i++) {
+    if (text.codeUnitAt(i) >= 128) {
+      isAscii = false;
+      break;
+    }
+  }
+
+  if (isAscii) {
+    if (len == width) return text;
+    if (len > width) return text.substring(0, width);
+    return text.padRight(width);
+  }
+
+  // 2. Slow-Path fallback for CJK and Emoji text
+  final cellWidth = measureStringWidth(text);
+  if (cellWidth == width) return text;
+  if (cellWidth < width) return text + (' ' * (width - cellWidth));
+
+  var currentWidth = 0;
+  final sb = StringBuffer();
+  for (final char in text.characters) {
+    final charWidth = isWideGrapheme(char) ? 2 : 1;
+    if (currentWidth + charWidth > width) break;
+    sb.write(char);
+    currentWidth += charWidth;
+  }
+  if (currentWidth < width) {
+    sb.write(' ' * (width - currentWidth));
+  }
+  return sb.toString();
+}
+
 /// A widget that renders styled text with optional wrapping.
 ///
 /// It supports standard formatting, custom maximum lines, and alignment.

--- a/packages/termui/test/ui/widgets/lazy_table_test.dart
+++ b/packages/termui/test/ui/widgets/lazy_table_test.dart
@@ -86,5 +86,51 @@ void main() {
       element.mount(null);
       element.layout(const BoxConstraints.tightFor(width: 20, height: 5));
     });
+
+    test('LazyTable handles wide characters and CJK without layout shifting', () {
+      final table = LazyTable(
+        headers: const ['Col1', 'Col2'],
+        columnWidths: const [10, 5],
+        itemCount: 2,
+        itemBuilder: (i) =>
+            i == 0 ? ['📁 folder', 'next'] : ['📁 folder exceeds width', 'val'],
+      );
+
+      final element = table.createElement();
+      element.mount(null);
+      element.layout(const BoxConstraints.tightFor(width: 20, height: 4));
+
+      final buffer = Buffer(20, 4);
+      element.paint(buffer, Offset.zero);
+
+      // Row 1 (first item, i == 0):
+      // Col 1 has width 10, followed by a 1-space separator.
+      // So 'next' in Col 2 should start exactly at x = 11.
+      expect(buffer.getCharacter(0, 2), equals('📁'));
+      expect(buffer.getCharacter(1, 2), equals('')); // Wide character marker
+      expect(buffer.getCharacter(2, 2), equals(' '));
+      expect(buffer.getCharacter(3, 2), equals('f'));
+      expect(buffer.getCharacter(11, 2), equals('n'));
+      expect(buffer.getCharacter(12, 2), equals('e'));
+
+      // Row 2 (second item, i == 1):
+      // Col 1 has width 10. The cell text is '📁 folder exceeds width'.
+      // With visual truncation:
+      // '📁' (2) + ' ' (1) + 'f' (1) + 'o' (1) + 'l' (1) + 'd' (1) + 'e' (1) + 'r' (1) + ' ' (1) = 10 visual width.
+      // So it should truncate to '📁 folder ' (excluding 'exceeds width').
+      // Let's verify buffer characters for Col 1 in row 2 (y == 3):
+      expect(buffer.getCharacter(0, 3), equals('📁'));
+      expect(buffer.getCharacter(1, 3), equals(''));
+      expect(buffer.getCharacter(2, 3), equals(' '));
+      expect(buffer.getCharacter(3, 3), equals('f'));
+      expect(buffer.getCharacter(4, 3), equals('o'));
+      expect(buffer.getCharacter(5, 3), equals('l'));
+      expect(buffer.getCharacter(6, 3), equals('d'));
+      expect(buffer.getCharacter(7, 3), equals('e'));
+      expect(buffer.getCharacter(8, 3), equals('r'));
+      expect(buffer.getCharacter(9, 3), equals(' '));
+      expect(buffer.getCharacter(10, 3), equals(' ')); // Separator space
+      expect(buffer.getCharacter(11, 3), equals('v')); // Start of Col 2
+    });
   });
 }

--- a/packages/termui/test/ui/widgets/table_test.dart
+++ b/packages/termui/test/ui/widgets/table_test.dart
@@ -1,0 +1,53 @@
+import 'package:termui/termui.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Table Tests', () {
+    test('Table handles wide characters and CJK without layout shifting', () {
+      final table = Table(
+        headers: const ['Col1', 'Col2'],
+        columnWidths: const [10, 5],
+        rows: const [
+          ['📁 folder', 'next'],
+          ['📁 folder exceeds width', 'val'],
+        ],
+      );
+
+      final element = table.createElement();
+      element.mount(null);
+      element.layout(const BoxConstraints.tightFor(width: 20, height: 4));
+
+      final buffer = Buffer(20, 4);
+      element.paint(buffer, Offset.zero);
+
+      // Row 1 (first item, y == 2):
+      // Col 1 has width 10, followed by a 1-space separator.
+      // So 'next' in Col 2 should start exactly at x = 11.
+      expect(buffer.getCharacter(0, 2), equals('📁'));
+      expect(buffer.getCharacter(1, 2), equals('')); // Wide character marker
+      expect(buffer.getCharacter(2, 2), equals(' '));
+      expect(buffer.getCharacter(3, 2), equals('f'));
+      expect(buffer.getCharacter(11, 2), equals('n'));
+      expect(buffer.getCharacter(12, 2), equals('e'));
+
+      // Row 2 (second item, y == 3):
+      // Col 1 has width 10. The cell text is '📁 folder exceeds width'.
+      // With visual truncation:
+      // '📁' (2) + ' ' (1) + 'f' (1) + 'o' (1) + 'l' (1) + 'd' (1) + 'e' (1) + 'r' (1) + ' ' (1) = 10 visual width.
+      // So it should truncate to '📁 folder ' (excluding 'exceeds width').
+      // Let's verify buffer characters for Col 1 in row 2 (y == 3):
+      expect(buffer.getCharacter(0, 3), equals('📁'));
+      expect(buffer.getCharacter(1, 3), equals(''));
+      expect(buffer.getCharacter(2, 3), equals(' '));
+      expect(buffer.getCharacter(3, 3), equals('f'));
+      expect(buffer.getCharacter(4, 3), equals('o'));
+      expect(buffer.getCharacter(5, 3), equals('l'));
+      expect(buffer.getCharacter(6, 3), equals('d'));
+      expect(buffer.getCharacter(7, 3), equals('e'));
+      expect(buffer.getCharacter(8, 3), equals('r'));
+      expect(buffer.getCharacter(9, 3), equals(' '));
+      expect(buffer.getCharacter(10, 3), equals(' ')); // Separator space
+      expect(buffer.getCharacter(11, 3), equals('v')); // Start of Col 2
+    });
+  });
+}


### PR DESCRIPTION
Introduces a `_padOrTruncate` helper to correctly measure and handle wide graphemes (such as Emojis and CJK characters) using `measureStringWidth` and `isWideGrapheme`. This prevents layout alignment issues and shifting when multi-byte or wide characters are present in table cells.

Also optimizes cell rendering by:
- Adding an ASCII fast-path to bypass character allocation for standard text.
- Replacing manual per-character buffer attribute iteration with `buffer.writeString`.
- Caching the total layout width of the columns.

Adds a test to verify proper layout handling of wide characters.

fixes #46 