### PR TITLE
chore(release): publish packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,45 @@ Packages with breaking changes:
 
 Packages with other changes:
 
+ - [`termui` - `v0.7.6`](#termui---v076)
+ - [`termui_flutter` - `v0.6.8`](#termui_flutter---v068)
+ - [`termui_recorder` - `v0.5.6+9`](#termui_recorder---v0569)
+ - [`termui_test` - `v0.2.7+10`](#termui_test---v02710)
+ - [`termui_hotreload` - `v0.6.9+6`](#termui_hotreload---v0696)
+ - [`termui_pty` - `v0.3.6`](#termui_pty---v036)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `termui_recorder` - `v0.5.6+9`
+ - `termui_test` - `v0.2.7+10`
+ - `termui_hotreload` - `v0.6.9+6`
+ - `termui_pty` - `v0.3.6`
+
+---
+
+#### `termui` - `v0.7.6`
+
+ - **FIX**(trace): resolve double-compression bug and decouple trace storage.
+
+#### `termui_flutter` - `v0.6.8`
+
+ - **FIX**(trace): resolve double-compression bug and decouple trace storage.
+
+
+## 2026-07-15
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
  - [`termui` - `v0.7.5`](#termui---v075)
  - [`termui_flutter` - `v0.6.7`](#termui_flutter---v067)
  - [`termui_pty` - `v0.3.5`](#termui_pty---v035)

--- a/packages/termui/CHANGELOG.md
+++ b/packages/termui/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.6
+
+ - **FIX**(trace): resolve double-compression bug and decouple trace storage.
+
 ## 0.7.5
 
  - **REFACTOR**(core): extract gzip_json compression logic into termui utilities.

--- a/packages/termui/pubspec.yaml
+++ b/packages/termui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: termui
 description: A high-performance terminal UI and windowing system for Dart featuring overlapping windows, double buffering, layouts, and sub-pixel vector graphics.
-version: 0.7.5
+version: 0.7.6
 repository: https://github.com/jtmcdole/termui/tree/main/packages/termui
 
 executables:

--- a/packages/termui_flutter/CHANGELOG.md
+++ b/packages/termui_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.8
+
+ - **FIX**(trace): resolve double-compression bug and decouple trace storage.
+
 ## 0.6.7
 
  - **REFACTOR**(core): extract gzip_json compression logic into termui utilities.

--- a/packages/termui_flutter/pubspec.yaml
+++ b/packages/termui_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: termui_flutter
 description: Flutter integration package for termui, containing the reusable Terminal widget and GPU-accelerated canvas renderer.
-version: 0.6.7
+version: 0.6.8
 repository: https://github.com/jtmcdole/termui/tree/main/packages/termui_flutter
 
 topics:
@@ -18,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  termui: ^0.7.5
+  termui: ^0.7.6
   characters: ^1.4.0
   clock: ^1.1.2
   web: ^1.1.1

--- a/packages/termui_hotreload/CHANGELOG.md
+++ b/packages/termui_hotreload/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.9+6
+
+ - Update a dependency to the latest release.
+
 ## 0.6.8+5
 
  - Update a dependency to the latest release.

--- a/packages/termui_hotreload/example/pubspec.yaml
+++ b/packages/termui_hotreload/example/pubspec.yaml
@@ -10,6 +10,6 @@ resolution: workspace
 
 
 dependencies:
-  termui: ^0.7.5
+  termui: ^0.7.6
   termui_hotreload:
     path: ../

--- a/packages/termui_hotreload/pubspec.yaml
+++ b/packages/termui_hotreload/pubspec.yaml
@@ -1,6 +1,6 @@
 name: termui_hotreload
 description: An optional companion package for termui that provides dead-simple automatic hot reloading during development.
-version: 0.6.8+5
+version: 0.6.9+6
 repository: https://github.com/jtmcdole/termui/tree/main/packages/termui_hotreload
 
 environment:
@@ -9,7 +9,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  termui: ^0.7.5
+  termui: ^0.7.6
   hotreloader: ^4.2.0
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/termui_pty/CHANGELOG.md
+++ b/packages/termui_pty/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.6
+
+ - Update a dependency to the latest release.
+
 ## 0.3.5
 
  - **FIX**(termui_pty): fix multi-byte emoji parsing in virtual terminal playback.

--- a/packages/termui_pty/pubspec.yaml
+++ b/packages/termui_pty/pubspec.yaml
@@ -1,6 +1,6 @@
 name: termui_pty
 description: A custom ANSI terminal emulator and PTY view for termui.
-version: 0.3.5
+version: 0.3.6
 repository: https://github.com/jtmcdole/termui/tree/main/packages/termui_pty
 
 resolution: workspace
@@ -21,13 +21,13 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
-  termui: ^0.7.5
+  termui: ^0.7.6
   pty2: ^0.5.1
   characters: ^1.4.0
 
 dev_dependencies:
   test: ">=1.24.0 <2.0.0"
-  termui_test: ^0.2.6+9
+  termui_test: ^0.2.7+10
   termui_shared_examples:
     path: ../termui_shared_examples
   benchmark_harness: ^2.2.0

--- a/packages/termui_recorder/CHANGELOG.md
+++ b/packages/termui_recorder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.6+9
+
+ - Update a dependency to the latest release.
+
 ## 0.5.5+8
 
  - Update a dependency to the latest release.

--- a/packages/termui_recorder/pubspec.yaml
+++ b/packages/termui_recorder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: termui_recorder
 description: Testing and recording utilities for termui, supporting ANSI screenshots, Asciinema v2 formats, and playbacks.
-version: 0.5.5+8
+version: 0.5.6+9
 repository: https://github.com/jtmcdole/termui/tree/main/packages/termui_recorder
 
 resolution: workspace
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
-  termui: ^0.7.5
+  termui: ^0.7.6
   characters: ^1.4.0
   args: ^2.7.0
   test: ">=1.24.0 <2.0.0"

--- a/packages/termui_test/CHANGELOG.md
+++ b/packages/termui_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.7+10
+
+ - Update a dependency to the latest release.
+
 ## 0.2.6+9
 
  - Update a dependency to the latest release.

--- a/packages/termui_test/pubspec.yaml
+++ b/packages/termui_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: termui_test
 description: Integration testing harness and utilities for the termui framework.
-version: 0.2.6+9
+version: 0.2.7+10
 repository: https://github.com/jtmcdole/termui/tree/main/packages/termui_test
 
 environment:
@@ -10,12 +10,12 @@ resolution: workspace
 
 dependencies:
   archive: ^4.0.9
-  termui: ^0.7.5
+  termui: ^0.7.6
   characters: ^1.4.0
   clock: ^1.1.2
   fake_async: ^1.3.3
   file: ^7.0.0
   meta: ^1.11.0
   test: ">=1.24.0 <2.0.0"
-  termui_recorder: ^0.5.5+8
+  termui_recorder: ^0.5.6+9
   test_api: ^0.7.11


### PR DESCRIPTION
 - termui@0.7.6
 - termui_flutter@0.6.8
 - termui_recorder@0.5.6+9
 - termui_test@0.2.7+10
 - termui_hotreload@0.6.9+6
 - termui_pty@0.3.6