### PR TITLE
feat(buffer): add active clip stack and enforce 2D spatial canvas clipping

### DIFF
--- a/packages/termui/lib/ui/buffer.dart
+++ b/packages/termui/lib/ui/buffer.dart
@@ -43,27 +43,53 @@ class Buffer {
     : characters = List.filled(width * height, ' '),
       attributes = Uint32List(width * height * 3);
 
+  /// Stack of active canvas clip rectangles.
+  final List<Rect> _clipStack = [];
+
+  /// Returns the current active clip rectangle, defaulting to full buffer bounds if stack is empty.
+  Rect get activeClip =>
+      _clipStack.isEmpty ? Rect(0, 0, width, height) : _clipStack.last;
+
+  /// Pushes a new clip rectangle onto the stack, intersecting it with the current active clip.
+  void pushClip(Rect clipRect) {
+    _clipStack.add(activeClip.intersect(clipRect));
+  }
+
+  /// Pops the most recently pushed clip rectangle from the stack.
+  void popClip() {
+    if (_clipStack.isNotEmpty) {
+      _clipStack.removeLast();
+    }
+  }
+
+  /// Whether cell ([x], [y]) is valid and inside the current active clip bounds.
+  bool isCellValid(int x, int y) {
+    if (x < 0 || x >= width || y < 0 || y >= height) return false;
+    if (_clipStack.isEmpty) return true;
+    return _clipStack.last.contains(x, y);
+  }
+
   /// Gets the character at ([x], [y]). Returns a space if coordinates are out of bounds.
   String getCharacter(int x, int y) {
-    if (x < 0 || x >= width || y < 0 || y >= height) return ' ';
+    if (!isCellValid(x, y)) return ' ';
     return characters[y * width + x];
   }
 
   /// Gets the foreground color at ([x], [y]). Returns 0 if coordinates are out of bounds.
   int getForeground(int x, int y) {
-    if (x < 0 || x >= width || y < 0 || y >= height) return 0;
+    if (!isCellValid(x, y)) return 0;
     return attributes[(y * width + x) * 3 + 0];
   }
 
   /// Gets the background color at ([x], [y]). Returns 0 if coordinates are out of bounds.
   int getBackground(int x, int y) {
-    if (x < 0 || x >= width || y < 0 || y >= height) return 0;
+    if (!isCellValid(x, y)) return 0;
     return attributes[(y * width + x) * 3 + 1];
   }
 
   /// Gets the modifiers at ([x], [y]). Returns transparent if coordinates are out of bounds.
   int getModifiers(int x, int y) {
-    if (x < 0 || x >= width || y < 0 || y >= height) {
+    if (!isCellValid(x, y)) {
       return Modifier.transparent;
     }
     return attributes[(y * width + x) * 3 + 2];
@@ -71,35 +97,35 @@ class Buffer {
 
   /// Sets character at coordinates.
   void setCharacter(int x, int y, String char) {
-    if (x >= 0 && x < width && y >= 0 && y < height) {
+    if (isCellValid(x, y)) {
       characters[y * width + x] = char;
     }
   }
 
   /// Sets foreground color at coordinates.
   void setForeground(int x, int y, int fg) {
-    if (x >= 0 && x < width && y >= 0 && y < height) {
+    if (isCellValid(x, y)) {
       attributes[(y * width + x) * 3 + 0] = fg;
     }
   }
 
   /// Sets background color at coordinates.
   void setBackground(int x, int y, int bg) {
-    if (x >= 0 && x < width && y >= 0 && y < height) {
+    if (isCellValid(x, y)) {
       attributes[(y * width + x) * 3 + 1] = bg;
     }
   }
 
   /// Sets modifiers at coordinates.
   void setModifiers(int x, int y, int mod) {
-    if (x >= 0 && x < width && y >= 0 && y < height) {
+    if (isCellValid(x, y)) {
       attributes[(y * width + x) * 3 + 2] = mod;
     }
   }
 
   /// Sets character, colors, and modifiers at coordinates.
   void setCell(int x, int y, String char, int fg, int bg, int mod) {
-    if (x >= 0 && x < width && y >= 0 && y < height) {
+    if (isCellValid(x, y)) {
       final idx = (y * width + x) * 3;
       characters[y * width + x] = char;
       attributes[idx + 0] = fg;
@@ -117,7 +143,7 @@ class Buffer {
     int? bg,
     int? modifiers,
   }) {
-    if (x < 0 || x >= width || y < 0 || y >= height) return;
+    if (!isCellValid(x, y)) return;
     final idx = (y * width + x) * 3;
     if (char != null) characters[y * width + x] = char;
     if (fg != null) attributes[idx + 0] = fg;
@@ -225,10 +251,7 @@ class Buffer {
           currentY++;
           continue;
         }
-        if (currentX >= 0 &&
-            currentX < width &&
-            currentY >= 0 &&
-            currentY < height) {
+        if (isCellValid(currentX, currentY)) {
           final idx = currentY * width + currentX;
           final char = String.fromCharCode(codeUnit);
 
@@ -305,10 +328,7 @@ class Buffer {
         currentY++;
         continue;
       }
-      if (currentX >= 0 &&
-          currentX < width &&
-          currentY >= 0 &&
-          currentY < height) {
+      if (isCellValid(currentX, currentY)) {
         final idx = currentY * width + currentX;
         // Clear potential wide char we are about to overwrite
         if (characters[idx] == '') {

--- a/packages/termui/lib/ui/widgets/core/geometry.dart
+++ b/packages/termui/lib/ui/widgets/core/geometry.dart
@@ -181,6 +181,34 @@ class Rect {
   /// Creates a new [Rect] with the specified [x], [y], [width], and [height].
   const Rect(this.x, this.y, this.width, this.height);
 
+  /// The left edge x-coordinate.
+  int get left => x;
+
+  /// The top edge y-coordinate.
+  int get top => y;
+
+  /// The right edge x-coordinate (exclusive).
+  int get right => x + width;
+
+  /// The bottom edge y-coordinate (exclusive).
+  int get bottom => y + height;
+
+  /// Whether ([cellX], [cellY]) is inside this rectangle.
+  bool contains(int cellX, int cellY) {
+    return cellX >= left && cellX < right && cellY >= top && cellY < bottom;
+  }
+
+  /// Calculates the intersection rectangle between this and [other].
+  Rect intersect(Rect other) {
+    final newLeft = left > other.left ? left : other.left;
+    final newTop = top > other.top ? top : other.top;
+    final newRight = right < other.right ? right : other.right;
+    final newBottom = bottom < other.bottom ? bottom : other.bottom;
+    final newWidth = (newRight - newLeft) < 0 ? 0 : newRight - newLeft;
+    final newHeight = (newBottom - newTop) < 0 ? 0 : newBottom - newTop;
+    return Rect(newLeft, newTop, newWidth, newHeight);
+  }
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/packages/termui/lib/ui/widgets/core/viewport.dart
+++ b/packages/termui/lib/ui/widgets/core/viewport.dart
@@ -51,6 +51,32 @@ class Viewport implements Buffer {
   );
 
   @override
+  Rect get activeClip => parent.activeClip;
+
+  @override
+  void pushClip(Rect clipRect) {
+    parent.pushClip(
+      Rect(
+        bounds.x + clipRect.x,
+        bounds.y + clipRect.y,
+        clipRect.width,
+        clipRect.height,
+      ),
+    );
+  }
+
+  @override
+  void popClip() {
+    parent.popClip();
+  }
+
+  @override
+  bool isCellValid(int x, int y) {
+    if (x < 0 || x >= bounds.width || y < 0 || y >= bounds.height) return false;
+    return parent.isCellValid(bounds.x + x, bounds.y + y);
+  }
+
+  @override
   String getCharacter(int x, int y) {
     if (x < 0 || x >= bounds.width || y < 0 || y >= bounds.height) return ' ';
     return parent.getCharacter(bounds.x + x, bounds.y + y);

--- a/packages/termui/test/ui/clip_bounds_test.dart
+++ b/packages/termui/test/ui/clip_bounds_test.dart
@@ -1,0 +1,83 @@
+import 'package:test/test.dart';
+import 'package:termui/termui.dart';
+
+class UnclippedRedBoxWidget extends Widget {
+  final int width;
+  final int height;
+
+  const UnclippedRedBoxWidget({
+    super.key,
+    required this.width,
+    required this.height,
+  });
+
+  @override
+  Element createElement() => UnclippedRedBoxElement(this);
+}
+
+class UnclippedRedBoxElement extends Element {
+  UnclippedRedBoxElement(super.widget);
+
+  @override
+  UnclippedRedBoxWidget get widget => super.widget as UnclippedRedBoxWidget;
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    return Size(widget.width, widget.height);
+  }
+
+  @override
+  void performPaint(Buffer buffer, Offset offset) {
+    final renderDx = offset.dx;
+    final renderDy = offset.dy;
+
+    for (int y = 0; y < size.height; y++) {
+      for (int x = 0; x < size.width; x++) {
+        final targetX = renderDx + x;
+        final targetY = renderDy + y;
+
+        buffer.setCell(targetX, targetY, 'X', 0xFFFF0000, 0, 0);
+      }
+    }
+  }
+}
+
+void main() {
+  test(
+    'Custom painter extending past right side of screen must be clipped and not wrap to column 0',
+    () {
+      final buffer = Buffer(80, 20);
+
+      // Create a 40x5 RedBox widget positioned at left: 60 on an 80-column terminal screen
+      // (Extends from column 60 to column 100)
+      final redBox = UnclippedRedBoxWidget(width: 40, height: 5);
+      final stack = Stack([
+        Positioned(left: 60, top: 0, width: 40, height: 5, child: redBox),
+      ]);
+
+      final rootElement = stack.createElement();
+      rootElement.mount(null);
+      rootElement.layout(
+        const BoxConstraints(
+          minWidth: 80,
+          maxWidth: 80,
+          minHeight: 20,
+          maxHeight: 20,
+        ),
+      );
+      rootElement.paint(buffer, Offset.zero);
+
+      // Columns 60 to 79 on row 0 should contain 'X'
+      expect(buffer.getCharacter(60, 0), equals('X'));
+      expect(buffer.getCharacter(79, 0), equals('X'));
+
+      // Column 0 on row 1 MUST NOT contain 'X' (proves no 1D index overflow wrapping to left side)
+      expect(
+        buffer.getCharacter(0, 1),
+        isNot(equals('X')),
+        reason:
+            'Out-of-bounds cells from column 80..99 must not wrap around to column 0..19 on row 1',
+      );
+    },
+  );
+}


### PR DESCRIPTION
Missed a couple

- Introduce _clipStack, pushClip(), popClip(), and activeClip to Buffer and Viewport for region clipping.
- Enhance Rect geometry with left, right, top, bottom, contains(), and intersect() helpers.
- Enforce 2D bounds checking via isCellValid() across all cell setters and writeString(), short-circuiting when _clipStack is empty to eliminate hot-loop object allocations.
- Prevent 1D flat-array index overflow and line-wrapping artifacts when painting off-screen elements.
- Add clip_bounds_test.dart to verify spatial clipping for out-of-bounds custom painting.