### PR TITLE
fix(layout): correctly calculate DecoratedBox intrinsic dimensions

### DIFF
--- a/packages/termui/lib/ui/widgets/display/decorated_box.dart
+++ b/packages/termui/lib/ui/widgets/display/decorated_box.dart
@@ -368,6 +368,8 @@ class DecoratedBox extends Widget {
 
 /// Element for [DecoratedBox].
 class DecoratedBoxElement extends SingleChildElement {
+  bool _bordersDirty = true;
+
   int _cachedTopOffset = 0;
   int _cachedBottomOffset = 0;
   int _cachedLeftOffset = 0;
@@ -388,7 +390,14 @@ class DecoratedBoxElement extends SingleChildElement {
   Widget? get childWidget => (widget as DecoratedBox).child;
 
   @override
-  Size performLayout(BoxConstraints constraints) {
+  void update(Widget newWidget) {
+    super.update(newWidget);
+    _bordersDirty = true;
+  }
+
+  void _computeBorderOffsets() {
+    if (!_bordersDirty) return;
+    _bordersDirty = false;
     final db = widget as DecoratedBox;
     final border = db.decoration.border;
 
@@ -422,18 +431,39 @@ class DecoratedBoxElement extends SingleChildElement {
         _cachedBottomOffset = 1;
       }
 
-      _cachedLeftOffset = [
+      _cachedLeftOffset = max(
         measureStringWidth(border.leftChar),
-        _topLeftCharWidth,
-        _bottomLeftCharWidth,
-      ].reduce(max);
+        max(_topLeftCharWidth, _bottomLeftCharWidth),
+      );
 
-      _cachedRightOffset = [
+      _cachedRightOffset = max(
         measureStringWidth(border.rightChar),
-        _topRightCharWidth,
-        _bottomRightCharWidth,
-      ].reduce(max);
+        max(_topRightCharWidth, _bottomRightCharWidth),
+      );
     }
+  }
+
+  @override
+  int getIntrinsicHeight(int width) {
+    _computeBorderOffsets();
+    final doubleWidth = _cachedLeftOffset + _cachedRightOffset;
+    final doubleHeight = _cachedTopOffset + _cachedBottomOffset;
+    final childWidth = max(0, width - doubleWidth);
+    return (childElement?.getIntrinsicHeight(childWidth) ?? 0) + doubleHeight;
+  }
+
+  @override
+  int getIntrinsicWidth(int height) {
+    _computeBorderOffsets();
+    final doubleWidth = _cachedLeftOffset + _cachedRightOffset;
+    final doubleHeight = _cachedTopOffset + _cachedBottomOffset;
+    final childHeight = max(0, height - doubleHeight);
+    return (childElement?.getIntrinsicWidth(childHeight) ?? 0) + doubleWidth;
+  }
+
+  @override
+  Size performLayout(BoxConstraints constraints) {
+    _computeBorderOffsets();
 
     final doubleWidth = _cachedLeftOffset + _cachedRightOffset;
     final doubleHeight = _cachedTopOffset + _cachedBottomOffset;

--- a/packages/termui/test/decorated_box_issue_test.dart
+++ b/packages/termui/test/decorated_box_issue_test.dart
@@ -1,0 +1,65 @@
+import 'package:termui/termui.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'DecoratedBox calculates correct intrinsic height under unbounded constraints',
+    () {
+      final menuBarRow = Row([
+        Text(' File ', style: const Style(foreground: Color(255, 255, 255))),
+      ]);
+
+      final w = Column([
+        DecoratedBox(
+          decoration: const BoxDecoration(border: Border.single),
+          child: menuBarRow,
+        ),
+      ]);
+
+      final rootElement = w.createElement();
+      rootElement.rebuild();
+      rootElement.layout(
+        BoxConstraints(
+          minWidth: 0,
+          maxWidth: 80,
+          minHeight: 0,
+          maxHeight: BoxConstraints.infinity,
+        ),
+      );
+
+      // The text is 1 high, + top border + bottom border = 3
+      expect(rootElement.size.height, greaterThanOrEqualTo(3));
+    },
+  );
+
+  test(
+    'DecoratedBox calculates correct intrinsic width under unbounded constraints',
+    () {
+      final menuCol = Column([
+        Text('File', style: const Style(foreground: Color(255, 255, 255))),
+      ]);
+
+      final w = Row([
+        DecoratedBox(
+          decoration: const BoxDecoration(border: Border.single),
+          child: menuCol,
+        ),
+      ]);
+
+      final rootElement = w.createElement();
+      rootElement.rebuild();
+      rootElement.layout(
+        BoxConstraints(
+          minWidth: 0,
+          maxWidth: BoxConstraints.infinity,
+          minHeight: 0,
+          maxHeight: 24,
+        ),
+      );
+
+      // The text is "File" (width 4).
+      // + left border (width 1) + right border (width 1) = 6
+      expect(rootElement.size.width, greaterThanOrEqualTo(6));
+    },
+  );
+}


### PR DESCRIPTION
Extracted border size metrics to a cached variable _bordersDirty to eliminate O(N) array allocations in the layout hot path and correctly incorporate border paddings into intrinsic width and height calculations. This ensures DecoratedBox no longer clips inside unbounded flex constraints.

Fixes: #102